### PR TITLE
fix(schema): avoid FRefStack use-after-free in TSchemaCompiler.Destroy

### DIFF
--- a/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
+++ b/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
@@ -507,9 +507,14 @@ end;
 
 destructor TSchemaCompiler.Destroy;
 begin
+  // ClearCache touches FRefStack/FNavigator/FCompiledSchemas/FBaseURIStack
+  // (FRefStack.Clear); it MUST run before those fields are freed. The previous
+  // order freed FRefStack and then ClearCache called FRefStack.Clear on the
+  // freed object -> use-after-free / heap corruption (caught via FastMM4
+  // FullDebugMode while consuming JsonFlow from FiscalBridge SpedFw).
+  ClearCache; // limpar cache enquanto os campos ainda estão vivos
   FreeAndNil(FNavigator);
   FRefStack.Free;
-  ClearCache; // Limpar cache antes de liberar o dicionário
   FCompiledSchemas.Free;
   // Fase 2: Limpar recursos Base URI e HTTP
   FBaseURIStack.Free;


### PR DESCRIPTION
## Problem

`TSchemaCompiler.Destroy` frees `FRefStack` and *then* calls `ClearCache`, but `ClearCache` calls `FRefStack.Clear` — invoking a method on the already-freed object.

```pascal
// before
FreeAndNil(FNavigator);
FRefStack.Free;          // FRefStack freed here
ClearCache;              // ClearCache -> FRefStack.Clear  (use-after-free)
FCompiledSchemas.Free;
```

Under **FastMM4 FullDebugMode** this raises `attempt to call a virtual method on a freed object`. Without FullDebugMode the freed block is silently reused and the heap is corrupted, surfacing as **flaky access violations in unrelated code** that happens to allocate around the same time.

## Impact

Every `TJSONSchemaReader` create/destroy builds and tears down a `TSchemaCompiler`, so any workload that loads many schemas (e.g. a large schema-driven test suite) corrupts the heap on a layout-dependent basis — green/red flips with unrelated code changes.

## Fix

Run `ClearCache` while the fields are still alive, then free them.

```pascal
// after
ClearCache;              // uses FRefStack/FNavigator/FCompiledSchemas/FBaseURIStack
FreeAndNil(FNavigator);
FRefStack.Free;
FCompiledSchemas.Free;
```

## Verification

Found and confirmed with **FastMM4 FullDebugMode** while consuming JsonFlow from a heavy schema-loading Delphi test suite: before the fix the event log recorded the use-after-free with full alloc/free/error stack traces; after the fix the event log is clean and the suite (3038 tests) is stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)