### PR TITLE
fix(utils): Iso8601ToDateTime aceita string so-data (yyyy-mm-dd)

### DIFF
--- a/Source/Core/JsonFlow.Utils.pas
+++ b/Source/Core/JsonFlow.Utils.pas
@@ -71,14 +71,23 @@ begin
     Exit;
   end;
   LYYYY := 0; LMM := 0; LDD := 0; LHH := 0; LMI := 0; LSS := 0; LMS := 0;
+  // A DATA (yyyy-mm-dd) e obrigatoria; a parte de HORA e OPCIONAL. Antes a cadeia
+  // AND exigia hh:nn:ss e devolvia 0 para uma string so-data, zerando datas de dia
+  // inteiro (vencimento/data-cadastro) no round-trip JSON. TryEncodeDateTime guarda
+  // valores invalidos (devolve 0 = comportamento anterior). Timestamp completo
+  // continua parseando identico (retrocompativel).
   if TryStrToInt(Copy(AValue, 1, 4), LYYYY) and
      TryStrToInt(Copy(AValue, 6, 2), LMM) and
-     TryStrToInt(Copy(AValue, 9, 2), LDD) and
-     TryStrToInt(Copy(AValue, 12, 2), LHH) and
-     TryStrToInt(Copy(AValue, 15, 2), LMI) and
-     TryStrToInt(Copy(AValue, 18, 2), LSS) then
+     TryStrToInt(Copy(AValue, 9, 2), LDD) then
   begin
-    Result := EncodeDateTime(LYYYY, LMM, LDD, LHH, LMI, LSS, LMS);
+    if Length(AValue) >= 19 then
+    begin
+      TryStrToInt(Copy(AValue, 12, 2), LHH);
+      TryStrToInt(Copy(AValue, 15, 2), LMI);
+      TryStrToInt(Copy(AValue, 18, 2), LSS);
+    end;
+    if not TryEncodeDateTime(LYYYY, LMM, LDD, LHH, LMI, LSS, LMS, Result) then
+      Result := 0;
   end
   else
     Result := 0;


### PR DESCRIPTION
## Bug
`Iso8601ToDateTime` (`Source/Core/JsonFlow.Utils.pas`) exigia um timestamp **completo** (`hh:nn:ss`) na cadeia `AND` e devolvia `0` para uma string **só-data** `"yyyy-mm-dd"`. Como `DateTimeToIso8601` emite só-data (`'yyyy-mm-dd'`, sem `'T'hh:nn:ss`) quando `Frac(valor)=0` (datas de dia inteiro), qualquer **data de dia inteiro** (vencimento, data de cadastro, emissão…) **não fazia round-trip** e voltava como `0` = `1899-12-30`.

Impacto: consumidores que desserializam JSON via este parse (ex.: ORM sobre datas) **zeravam toda coluna DATE** no insert/overlay. Strings/números não eram afetados.

## Fix
A **data** passa a ser obrigatória e a **hora opcional** (parseada só quando `Length(AValue) >= 19`). `TryEncodeDateTime` guarda valores inválidos (devolve `0`, comportamento anterior). **Retrocompatível:** timestamp completo (`yyyy-mm-ddThh:nn:ss`) continua parseando idêntico.

## Teste
- `Iso8601ToDateTime('2026-07-28', True)` → `EncodeDate(2026,7,28)` (antes: `0`).
- `Iso8601ToDateTime('2026-07-28T13:45:00', True)` → mantém a hora (idêntico ao anterior).
- Validado live (Firebird WIN1252) num backend consumidor: POST com `"vencimento":"2026-07-28"` → coluna DATE gravou `2026-07-28` (antes: `1899-12-30`); suíte do consumidor 2807/2807 verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)