### PR TITLE
refactor(style): rename old single-letter loop variables 'I' to 'LFor'

### DIFF
--- a/Source/JSON/Composition/JsonFlow.Composer.pas
+++ b/Source/JSON/Composition/JsonFlow.Composer.pas
@@ -1329,14 +1329,14 @@ function TJSONComposer.SuggestKeys: TArray<String>;
 var
   LSuggestions: TArray<TJSONSuggestion>;
   LKeys: TList<String>;
-  I: Integer;
+  LFor: Integer;
 begin
   LSuggestions := GetSuggestions;
   LKeys := TList<String>.Create;
   try
-    for I := 0 to Length(LSuggestions) - 1 do
-      if LSuggestions[I].SuggestionType = 'key' then
-        LKeys.Add(LSuggestions[I].Value);
+    for LFor := 0 to Length(LSuggestions) - 1 do
+      if LSuggestions[LFor].SuggestionType = 'key' then
+        LKeys.Add(LSuggestions[LFor].Value);
     Result := LKeys.ToArray;
   finally
     LKeys.Free;

--- a/Source/JSON/IO/JsonFlow.Converter.Dataset.pas
+++ b/Source/JSON/IO/JsonFlow.Converter.Dataset.pas
@@ -410,16 +410,16 @@ end;
 
 procedure TJSONDatasetConverter.AddFieldDefs(AComposer: IJSONComposer; ADataset: TDataset);
 var
-  I: Integer;
+  LFor: Integer;
 begin
   AComposer.BeginArray('fieldDefs');
-  for I := 0 to ADataset.FieldDefs.Count - 1 do
+  for LFor := 0 to ADataset.FieldDefs.Count - 1 do
   begin
     AComposer.BeginObject
-      .Add('name', ADataset.FieldDefs[I].Name)
-      .Add('dataType', Ord(ADataset.FieldDefs[I].DataType))
-      .Add('size', ADataset.FieldDefs[I].Size)
-      .Add('required', ADataset.FieldDefs[I].Required)
+      .Add('name', ADataset.FieldDefs[LFor].Name)
+      .Add('dataType', Ord(ADataset.FieldDefs[LFor].DataType))
+      .Add('size', ADataset.FieldDefs[LFor].Size)
+      .Add('required', ADataset.FieldDefs[LFor].Required)
     .EndObject;
   end;
   AComposer.EndArray;
@@ -482,16 +482,16 @@ end;
 function TJSONDatasetConverter.RecordToJSONObject(ADataset: TDataset): IJSONObject;
 var
   LObject: IJSONObject;
-  I: Integer;
+  LFor: Integer;
   LField: TField;
   LFieldName: string;
   LElement: IJSONElement;
 begin
   LObject := TJSONObject.Create;
   
-  for I := 0 to ADataset.FieldCount - 1 do
+  for LFor := 0 to ADataset.FieldCount - 1 do
   begin
-    LField := ADataset.Fields[I];
+    LField := ADataset.Fields[LFor];
     LFieldName := FormatFieldName(LField.FieldName);
     LElement := ConvertFieldValue(LField);
     
@@ -531,7 +531,7 @@ end;
 
 procedure TJSONDatasetConverter.JSONArrayToDataset(AArray: IJSONArray; ADataset: TDataset; const AClearFirst: Boolean);
 var
-  I: Integer;
+  LFor: Integer;
   LObject: IJSONObject;
 begin
   if AClearFirst then
@@ -541,9 +541,9 @@ begin
 //    ADataset.EmptyDataSet;
   end;
   
-  for I := 0 to AArray.Count - 1 do
+  for LFor := 0 to AArray.Count - 1 do
   begin
-    if Supports(AArray.GetItem(I), IJSONObject, LObject) then
+    if Supports(AArray.GetItem(LFor), IJSONObject, LObject) then
     begin
       ADataset.Append;
       try
@@ -559,14 +559,14 @@ end;
 
 procedure TJSONDatasetConverter.JSONObjectToRecord(AObject: IJSONObject; ADataset: TDataset);
 var
-  I: Integer;
+  LFor: Integer;
   LField: TField;
   LFieldName: string;
   LElement: IJSONElement;
 begin
-  for I := 0 to ADataset.FieldCount - 1 do
+  for LFor := 0 to ADataset.FieldCount - 1 do
   begin
-    LField := ADataset.Fields[I];
+    LField := ADataset.Fields[LFor];
     LFieldName := FormatFieldName(LField.FieldName);
     
     if AObject.ContainsKey(LFieldName) then
@@ -612,7 +612,7 @@ var
   LComposer: TJSONComposer;
   LObject: IJSONObject;
   LChangedFields: TList<string>;
-  I: Integer;
+  LFor: Integer;
   LField: TField;
   LFieldName: string;
   LElement: IJSONElement;
@@ -624,9 +624,9 @@ begin
     LComposer.LoadJSON(AJSON);
 //    if Supports(LComposer.GetJSONElement, IJSONObject, LObject) then
 //    begin
-//      for I := 0 to ADataset.FieldCount - 1 do
+//      for LFor := 0 to ADataset.FieldCount - 1 do
 //      begin
-//        LField := ADataset.Fields[I];
+//        LField := ADataset.Fields[LFor];
 //        LFieldName := FormatFieldName(LField.FieldName);
 //
 //        if LObject.ContainsKey(LFieldName) then

--- a/Source/JSON/IO/JsonFlow.Converter.XML.pas
+++ b/Source/JSON/IO/JsonFlow.Converter.XML.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -313,7 +313,7 @@ var
   LChildElements: TDictionary<string, TList<IXMLNode>>;
   LElementName: string;
   LElementList: TList<IXMLNode>;
-  I: Integer;
+  LFor: Integer;
   LTextContent: string;
   LHasAttributes: Boolean;
   LHasChildren: Boolean;
@@ -380,9 +380,9 @@ begin
     case FXMLToJSONOptions.AttributeHandling of
       ahAsProperties:
         begin
-          for I := 0 to ANode.AttributeNodes.Count - 1 do
+          for LFor := 0 to ANode.AttributeNodes.Count - 1 do
           begin
-            LChildNode := ANode.AttributeNodes[I];
+            LChildNode := ANode.AttributeNodes[LFor];
             LObject.Add(FXMLToJSONOptions.AttributePrefix + LChildNode.NodeName, 
                        DetectValueType(LChildNode.Text));
           end;
@@ -390,9 +390,9 @@ begin
       ahAsMetadata:
         begin
           var LMetadata := TJSONObject.Create;
-          for I := 0 to ANode.AttributeNodes.Count - 1 do
+          for LFor := 0 to ANode.AttributeNodes.Count - 1 do
           begin
-            LChildNode := ANode.AttributeNodes[I];
+            LChildNode := ANode.AttributeNodes[LFor];
             LMetadata.Add(LChildNode.NodeName, DetectValueType(LChildNode.Text));
           end;
           LObject.Add('metadata', LMetadata);
@@ -403,9 +403,9 @@ begin
   // Agrupar elementos filhos por nome
   LChildElements := TDictionary<string, TList<IXMLNode>>.Create;
   try
-    for I := 0 to ANode.ChildNodes.Count - 1 do
+    for LFor := 0 to ANode.ChildNodes.Count - 1 do
     begin
-      LChildNode := ANode.ChildNodes[I];
+      LChildNode := ANode.ChildNodes[LFor];
       LElementName := LChildNode.NodeName;
       
       if not LChildElements.ContainsKey(LElementName) then
@@ -456,14 +456,14 @@ end;
 
 function TJSONXMLConverter.ProcessXMLAttributes(ANode: IXMLNode): IJSONObject;
 var
-  I: Integer;
+  LFor: Integer;
   LAttrNode: IXMLNode;
 begin
   Result := TJSONObject.Create;
   
-  for I := 0 to ANode.AttributeNodes.Count - 1 do
+  for LFor := 0 to ANode.AttributeNodes.Count - 1 do
   begin
-    LAttrNode := ANode.AttributeNodes[I];
+    LAttrNode := ANode.AttributeNodes[LFor];
     Result.Add(FXMLToJSONOptions.AttributePrefix + LAttrNode.NodeName, 
                DetectValueType(LAttrNode.Text));
   end;
@@ -601,7 +601,7 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
   LValue: IJSONValue;
-  I: Integer;
+  LFor: Integer;
   LKey: string;
   LChildElement: IJSONElement;
 begin
@@ -612,9 +612,9 @@ begin
   begin
     LNewNode := AParentNode.AddChild(SanitizeElementName(AElementName));
     
-    for I := 0 to LObject.Count - 1 do
+    for LFor := 0 to LObject.Count - 1 do
     begin
-//      LKey := LObject.GetKey(I);
+//      LKey := LObject.GetKey(LFor);
       LChildElement := LObject.GetValue(LKey);
       
       // Verificar se é atributo
@@ -638,9 +638,9 @@ begin
   end
   else if Supports(AElement, IJSONArray, LArray) then
   begin
-    for I := 0 to LArray.Count - 1 do
+    for LFor := 0 to LArray.Count - 1 do
     begin
-      LChildElement := LArray.GetItem(I);
+      LChildElement := LArray.GetItem(LFor);
       ProcessJSONToXML(LChildElement, AParentNode, AElementName);
     end;
   end
@@ -922,16 +922,16 @@ function TMixedContentConverter.XMLToJSON(ANode: IXMLNode): IJSONElement;
 var
   LObject: IJSONObject;
   LArray: IJSONArray;
-  I: Integer;
+  LFor: Integer;
   LChildNode: IXMLNode;
 begin
   LObject := TJSONObject.Create;
   LArray := TJSONArray.Create;
   
   // Processar conteúdo misto como array de elementos
-  for I := 0 to ANode.ChildNodes.Count - 1 do
+  for LFor := 0 to ANode.ChildNodes.Count - 1 do
   begin
-    LChildNode := ANode.ChildNodes[I];
+    LChildNode := ANode.ChildNodes[LFor];
     
     if LChildNode.NodeType = ntText then
     begin


### PR DESCRIPTION
- Standardized loop variable declarations across Dataset, XML, and Composer modules to align with project's modern pascal naming conventions (LFor/LIndex).