### PR TITLE
perf: phase 1 hot-path optimizations (parse ~1000x, deser -40%, ser -20%)

### DIFF
--- a/Source/JSON/Core/JsonFlow.Value.pas
+++ b/Source/JSON/Core/JsonFlow.Value.pas
@@ -187,13 +187,15 @@ type
 
 implementation
 
+var
+  // TFormatSettings.Create('en-US') consulta o locale do SO (API NLS) — pagar
+  // isso por instância de valor JSON dominava o custo do parse. Inicializa uma
+  // vez e copia o record (strings refcounted, cópia barata).
+  GValueFormatSettings: TFormatSettings;
+
 constructor TJSONValue.Create;
 begin
-  FFormatSettings := TFormatSettings.Create('en-US');
-  FFormatSettings.ShortDateFormat := 'yyyy-mm-dd';
-  FFormatSettings.DateSeparator := '-';
-  FFormatSettings.TimeSeparator := ':';
-  FFormatSettings.DecimalSeparator := '.';
+  FFormatSettings := GValueFormatSettings;
 end;
 
 destructor TJSONValue.Destroy;
@@ -703,5 +705,12 @@ procedure TJSONValueDateTime._SetAsString(const AValue: String);
 begin
   FValue := Iso8601ToDateTime(AValue, True);
 end;
+
+initialization
+  GValueFormatSettings := TFormatSettings.Create('en-US');
+  GValueFormatSettings.ShortDateFormat := 'yyyy-mm-dd';
+  GValueFormatSettings.DateSeparator := '-';
+  GValueFormatSettings.TimeSeparator := ':';
+  GValueFormatSettings.DecimalSeparator := '.';
 
 end.

--- a/Source/JSON/IO/JsonFlow.Reader.pas
+++ b/Source/JSON/IO/JsonFlow.Reader.pas
@@ -183,7 +183,11 @@ begin
           'u': begin
                  Inc(AIndex);
                  if AIndex + 3 < ALength then
-                   LBuilder.Append(Char(StrToInt('$'+Copy(AJson+AIndex, 0, 4))))
+                 begin
+                   var LHex: string;
+                   SetString(LHex, AJson + AIndex, 4);
+                   LBuilder.Append(Char(StrToInt('$' + LHex)));
+                 end
                  else
                    raise EJsonFlowParseError.Create('Invalid unicode escape');
                  Inc(AIndex, 3);
@@ -266,7 +270,9 @@ begin
       LIsFloat := True;
     Inc(AIndex);
   end;
-  LStr := Copy(AJson, LStart + 1, AIndex - LStart);
+  // SetString copia só o trecho do número — Copy(AJson, ...) com PChar
+  // convertia o restante inteiro do buffer para String a cada número (O(n²)).
+  SetString(LStr, AJson + LStart, AIndex - LStart);
   if LIsFloat then
     Result := TJSONValueFloat.Create(StrToFloatDef(LStr, 0.0, FFormatSettings))
   else
@@ -341,8 +347,10 @@ begin
              LValue := TJSONValueString.Create(LString);
            Result := LValue;
          end;
+    // StrLComp compara in-place — Copy(AJson + AIndex, ...) com PChar convertia
+    // o restante inteiro do buffer para String a cada literal (O(n²)).
     't': begin
-           if Copy(AJson + AIndex, 1, 4) = 'true' then
+           if (AIndex + 3 < ALength) and (StrLComp(AJson + AIndex, 'true', 4) = 0) then
            begin
              LValue := TJSONValueBoolean.Create(True);
              Result := LValue;
@@ -352,7 +360,7 @@ begin
              raise EJsonFlowParseError.Create('Invalid JSON value');
          end;
     'f': begin
-           if Copy(AJson + AIndex, 1, 5) = 'false' then
+           if (AIndex + 4 < ALength) and (StrLComp(AJson + AIndex, 'false', 5) = 0) then
            begin
              LValue := TJSONValueBoolean.Create(False);
              Result := LValue;
@@ -362,7 +370,7 @@ begin
              raise EJsonFlowParseError.Create('Invalid JSON value');
          end;
     'n': begin
-           if Copy(AJson + AIndex, 1, 4) = 'null' then
+           if (AIndex + 3 < ALength) and (StrLComp(AJson + AIndex, 'null', 4) = 0) then
            begin
              LValue := TJSONValueNull.Create;
              Result := LValue;

--- a/Source/JSON/IO/JsonFlow.Serializer.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.pas
@@ -76,7 +76,7 @@ type
     FContext: TRttiContext;
     FTypeCache: TDictionary<TClass, TPair<TRttiType, TList<TRttiProperty>>>;
     procedure _Log(const AMessage: string);
-    procedure _CacheType(AClass: TClass);
+    function _GetCachedType(AClass: TClass): TPair<TRttiType, TList<TRttiProperty>>;
     procedure _JSONToProperty(const AProperty: TRttiProperty; const AInstance: TObject;
       const AElement: IJSONElement);
     function _JSONFromProperty(const AProperty: TRttiProperty; const AInstance: TObject;
@@ -206,31 +206,34 @@ begin
     FLogProc(AMessage);
 end;
 
-procedure TJSONSerializer._CacheType(AClass: TClass);
+function TJSONSerializer._GetCachedType(AClass: TClass): TPair<TRttiType, TList<TRttiProperty>>;
 var
   LRttiType: TRttiType;
   LProperties: TList<TRttiProperty>;
   LProp: TRttiProperty;
 begin
-  if not FTypeCache.ContainsKey(AClass) then
-  begin
-    LRttiType := FContext.GetType(AClass);
-    if not Assigned(LRttiType) then
-      raise EInvalidOperation.Create('RTTI not available for class ' + AClass.ClassName);
-    LProperties := TList<TRttiProperty>.Create;
-    try
-      for LProp in LRttiType.GetProperties do
+  // TryGetValue único no hit — antes eram 2-3 buscas no dicionário por objeto
+  // (ContainsKey no _CacheType + FTypeCache[LClass] no chamador).
+  if FTypeCache.TryGetValue(AClass, Result) then
+    Exit;
+
+  LRttiType := FContext.GetType(AClass);
+  if not Assigned(LRttiType) then
+    raise EInvalidOperation.Create('RTTI not available for class ' + AClass.ClassName);
+  LProperties := TList<TRttiProperty>.Create;
+  try
+    for LProp in LRttiType.GetProperties do
+    begin
+      if LProp.IsReadable then
       begin
-        if LProp.IsReadable then
-        begin
-          LProperties.Add(LProp);
-        end;
+        LProperties.Add(LProp);
       end;
-      FTypeCache.Add(AClass, TPair<TRttiType, TList<TRttiProperty>>.Create(LRttiType, LProperties));
-    except
-      LProperties.Free;
-      raise;
     end;
+    Result := TPair<TRttiType, TList<TRttiProperty>>.Create(LRttiType, LProperties);
+    FTypeCache.Add(AClass, Result);
+  except
+    LProperties.Free;
+    raise;
   end;
 end;
 
@@ -511,7 +514,10 @@ begin
     tkFloat:
       if Supports(AElement, IJSONValue, LValueInterface) then
       begin
-        _Log('Property: ' + AProperty.Name + ', Class: ' + AInstance.ClassName + ', Value: ' + LValueInterface.AsJSON);
+        // Monta a mensagem só com log ativo — o argumento era avaliado sempre
+        // (3 concatenações + AsJSON) para cada propriedade float/date.
+        if Assigned(FLogProc) then
+          _Log('Property: ' + AProperty.Name + ', Class: ' + AInstance.ClassName + ', Value: ' + LValueInterface.AsJSON);
         if LValueInterface is TJSONValueDateTime then
           AProperty.SetValue(AInstance, TJSONValueDateTime(LValueInterface).Value)
         else if LValueInterface is TJSONValueFloat then
@@ -612,8 +618,7 @@ begin
     raise EArgumentNilException.Create('Object cannot be nil');
 
   LClass := AObject.ClassType;
-  _CacheType(LClass);
-  LTypeInfo := FTypeCache[LClass];
+  LTypeInfo := _GetCachedType(LClass);
 
   LJsonObj := TJSONObject.Create;
   try
@@ -676,8 +681,7 @@ begin
     raise EArgumentException.Create('Element must be a JSON object');
 
   LClass := AObject.ClassType;
-  _CacheType(LClass);
-  LTypeInfo := FTypeCache[LClass];
+  LTypeInfo := _GetCachedType(LClass);
 
   for LProp in LTypeInfo.Value do
   begin
@@ -835,8 +839,7 @@ begin
   end;
 
   LClass := AObject.ClassType;
-  _CacheType(LClass);
-  LTypeInfo := FTypeCache[LClass];
+  LTypeInfo := _GetCachedType(LClass);
 
   ABuilder.Append('{');
   LFirst := True;

--- a/Tests/Schema/JsonFlow.Schema.Tests.dproj
+++ b/Tests/Schema/JsonFlow.Schema.Tests.dproj
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{7C6F2EC5-AA1D-453B-9C33-49ED20D7A24E}</ProjectGuid>
         <MainSource>JsonFlow.Schema.Tests.dpr</MainSource>
@@ -54,7 +54,7 @@
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-        <DCC_UnitSearchPath>..\..\..\JsonFlow\Source;..\..\..\JsonFlow\Source\Addons;..\..\..\JsonFlow\Source\JSON;..\..\..\JsonFlow\Source\Schema;..\..\..\JsonFlow\Source\Addons\Composition;..\..\..\JsonFlow\Source\Addons\Validation;..\..\..\JsonFlow\Source\JSON\Composition;..\..\..\JsonFlow\Source\JSON\Core;..\..\..\JsonFlow\Source\JSON\IO;..\..\..\JsonFlow\Source\JSON\Middleware;..\..\..\JsonFlow\Source\Schema\Composition;..\..\..\JsonFlow\Source\Schema\Core;..\..\..\JsonFlow\Source\Schema\IO;..\..\..\JsonFlow\Source\Schema\Validators;..\..\..\JsonFlow\Source\Schema\Validators\Format;..\..\..\JsonFlow\Source\Schema\Validators\Format\Brazil;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\..\JsonFlow\Source;..\..\..\JsonFlow\Source\Core;..\..\..\JsonFlow\Source\Addons;..\..\..\JsonFlow\Source\JSON;..\..\..\JsonFlow\Source\Schema;..\..\..\JsonFlow\Source\Addons\Composition;..\..\..\JsonFlow\Source\Addons\Validation;..\..\..\JsonFlow\Source\JSON\Composition;..\..\..\JsonFlow\Source\JSON\Core;..\..\..\JsonFlow\Source\JSON\IO;..\..\..\JsonFlow\Source\JSON\Middleware;..\..\..\JsonFlow\Source\Schema\Composition;..\..\..\JsonFlow\Source\Schema\Core;..\..\..\JsonFlow\Source\Schema\IO;..\..\..\JsonFlow\Source\Schema\Validators;..\..\..\JsonFlow\Source\Schema\Validators\Format;..\..\..\JsonFlow\Source\Schema\Validators\Format\Brazil;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>


### PR DESCRIPTION
## Origem

Auditoria de performance nos hot paths de serialização/deserialização (pós-benchmark vs X-SuperObject). Esta é a **Fase 1**: só fixes pontuais de risco baixíssimo, **zero mudança de comportamento**.

## Os 4 fixes

| # | Arquivo | Problema | Fix |
|---|---|---|---|
| 1 | `JsonFlow.Reader.pas` | `Copy()` sobre `PChar` convertia **o buffer restante inteiro** para String a cada número e a cada literal `true/false/null` → parse **O(n²)** no tamanho do documento | `SetString`/`StrLComp` in-place |
| 2 | `JsonFlow.Value.pas` | `TFormatSettings.Create('en-US')` (consulta de locale ao SO) no construtor de **todo** valor JSON | Inicializado 1× no unit, record copiado |
| 3 | `JsonFlow.Serializer.pas` | Argumento do log (3 concats + `AsJSON` completo) montado para toda propriedade float/date **mesmo com log desligado** | Guard `Assigned(FLogProc)` |
| 4 | `JsonFlow.Serializer.pas` | 2-3 lookups no dicionário de cache de tipo por objeto | `TryGetValue` único (`_GetCachedType`) |

\+ `Tests/Schema/*.dproj`: adiciona `Source\Core` ao search path (faltava; mascarado por dcu obsoleto).

## Números (harness console, mediana de 3 runs, Release Win32)

| Dataset | Parse | Deserialização | Serialização |
|---|---|---|---|
| users-50k | **~150.000ms → 132ms (~1000×)** | 177ms → 107ms (**-40%**) | 84ms → 74ms (-12%) |
| customers-5k | 620ms → 110ms (**~5×**) | 70ms → 53ms (**-25%**) | 30ms → 22ms (**-27%**) |

O parse do users-50k levava 2,5 minutos por causa do O(n²) — o dataset tem 50K números; o customers não tem nenhum campo numérico, por isso nunca doeu ali.

## Validação

- ✅ Saída serializada **byte-idêntica** (SHA256) antes/depois nos dois datasets
- ✅ Suíte Schema: **104/104 testes verdes**
- ✅ Round-trip completo users-50k + customers-5k sem erro

## Não incluído (próximas fases da auditoria)

Fase 2: índice hash no `TJSONObject` (lookup linear `SameText`). Fase 3: fast-path no `_EscapeString`, formatação de data sem `FormatDateTime`, capacidade inicial do builder. Fase 4: Writer sem materializar subárvores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)