### PR TITLE
perf: fase 3 — serialização (escape fast-path, dígitos de data, capacidade do builder)

### DIFF
--- a/Source/Core/JsonFlow.Utils.pas
+++ b/Source/Core/JsonFlow.Utils.pas
@@ -35,22 +35,57 @@ function DateTimeToIso8601(const AValue: TDateTime;
 var
   LDatePart: String;
   LTimePart: String;
+  LYear, LMonth, LDay: Word;
+  LHour, LMin, LSec, LMSec: Word;
+  P: PChar;
+
+  procedure _Put2(APos: Integer; AVal: Word);
+  begin
+    P[APos]     := Char(Ord('0') + (AVal div 10));
+    P[APos + 1] := Char(Ord('0') + (AVal mod 10));
+  end;
+
 begin
   Result := '';
   if AValue = 0 then
     Exit;
 
   if AUseISO8601DateFormat then
-    LDatePart := FormatDateTime('yyyy-mm-dd', AValue)
-  else
-    LDatePart := DateToStr(AValue, GJsonFlowFormatSettings);
+  begin
+    // Escrita direta dos dígitos — FormatDateTime reparseava a máscara
+    // ('yyyy-mm-dd'/'hh:nn:ss') a cada chamada, e este é o caminho quente
+    // de toda data serializada.
+    DecodeDate(AValue, LYear, LMonth, LDay);
+    if Frac(AValue) = 0 then
+    begin
+      SetLength(Result, 10);
+      P := PChar(Result);
+      _Put2(0, LYear div 100); _Put2(2, LYear mod 100);
+      P[4] := '-'; _Put2(5, LMonth);
+      P[7] := '-'; _Put2(8, LDay);
+    end
+    else
+    begin
+      DecodeTime(AValue, LHour, LMin, LSec, LMSec);
+      SetLength(Result, 19);
+      P := PChar(Result);
+      _Put2(0, LYear div 100); _Put2(2, LYear mod 100);
+      P[4] := '-'; _Put2(5, LMonth);
+      P[7] := '-'; _Put2(8, LDay);
+      P[10] := 'T'; _Put2(11, LHour);
+      P[13] := ':'; _Put2(14, LMin);
+      P[16] := ':'; _Put2(17, LSec);
+    end;
+    Exit;
+  end;
 
+  LDatePart := DateToStr(AValue, GJsonFlowFormatSettings);
   if Frac(AValue) = 0 then
-    Result := ifThen(AUseISO8601DateFormat, LDatePart, DateToStr(AValue, GJsonFlowFormatSettings))
+    Result := LDatePart
   else
   begin
     LTimePart := FormatDateTime('hh:nn:ss', AValue);
-    Result := ifThen(AUseISO8601DateFormat, LDatePart + 'T' + LTimePart, LDatePart + ' ' + LTimePart);
+    Result := LDatePart + ' ' + LTimePart;
   end;
 end;
 

--- a/Source/JSON/Core/JsonFlow.Value.pas
+++ b/Source/JSON/Core/JsonFlow.Value.pas
@@ -258,11 +258,27 @@ end;
 function TJSONValueString.AsJSON(const AIdent: Boolean = False): String;
 var
   LBuilder: TStringBuilder;
-  LResult: String;
   LFor: Integer;
   LChar: Char;
+  LNeedsEscape: Boolean;
 begin
-  LBuilder := TStringBuilder.Create;
+  // Fast-path: sem nada a escapar (caso comum), monta por concatenação direta
+  // — sem TStringBuilder nem varredura de append char a char.
+  LNeedsEscape := False;
+  for LFor := 1 to Length(FValue) do
+  begin
+    LChar := FValue[LFor];
+    if (LChar = '"') or (LChar = '\') or (LChar < #32) then
+    begin
+      LNeedsEscape := True;
+      Break;
+    end;
+  end;
+
+  if not LNeedsEscape then
+    Exit('"' + FValue + '"');
+
+  LBuilder := TStringBuilder.Create(Length(FValue) + 16);
   try
     LBuilder.Append('"');
     for LFor := 1 to Length(FValue) do
@@ -283,11 +299,10 @@ begin
       end;
     end;
     LBuilder.Append('"');
-    LResult := LBuilder.ToString;
+    Result := LBuilder.ToString;
   finally
     LBuilder.Free;
   end;
-  Result := LResult;
 end;
 
 function TJSONValueString.Clone: IJSONElement;

--- a/Source/JSON/IO/JsonFlow.Serializer.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.pas
@@ -90,7 +90,7 @@ type
     // Direct stream private writers
     procedure _WriteObject(AObject: TObject; ABuilder: TStringBuilder; const AStoreClassName: Boolean);
     procedure _WriteTValue(const AValue: TValue; ABuilder: TStringBuilder; const AStoreClassName: Boolean);
-    function _EscapeString(const AValue: string): string;
+    procedure _AppendEscapedString(const AValue: string; ABuilder: TStringBuilder);
   public
     constructor Create; overload;
     constructor Create(const AFormatSettings: TFormatSettings; const AUseISO8601DateFormat: Boolean = True); overload;
@@ -714,35 +714,44 @@ begin
   Result := True;
 end;
 
-function TJSONSerializer._EscapeString(const AValue: string): string;
+procedure TJSONSerializer._AppendEscapedString(const AValue: string; ABuilder: TStringBuilder);
 var
-  LBuilder: TStringBuilder;
   LFor: Integer;
+  LStart: Integer;
+  LLen: Integer;
   LChar: Char;
 begin
-  LBuilder := TStringBuilder.Create;
-  try
-    for LFor := 1 to Length(AValue) do
+  // Fast-path: a imensa maioria das strings não tem nada a escapar — copia
+  // trechos "limpos" em bloco direto no builder de destino, sem builder
+  // intermediário nem string temporária (antes: 1 TStringBuilder + 1 cópia
+  // por valor string serializado).
+  LLen := Length(AValue);
+  LStart := 1;
+  for LFor := 1 to LLen do
+  begin
+    LChar := AValue[LFor];
+    if (LChar = '"') or (LChar = '\') or (LChar < #32) then
     begin
-      LChar := AValue[LFor];
+      if LFor > LStart then
+        ABuilder.Append(AValue, LStart - 1, LFor - LStart);
       case LChar of
-        '"': LBuilder.Append('\"');
-        '\': LBuilder.Append('\\');
-        #8: LBuilder.Append('\b');
-        #9: LBuilder.Append('\t');
-        #10: LBuilder.Append('\n');
-        #12: LBuilder.Append('\f');
-        #13: LBuilder.Append('\r');
-        #0..#7, #11, #14..#31:
-          LBuilder.Append('\u00' + IntToHex(Ord(LChar), 2));
+        '"': ABuilder.Append('\"');
+        '\': ABuilder.Append('\\');
+        #8: ABuilder.Append('\b');
+        #9: ABuilder.Append('\t');
+        #10: ABuilder.Append('\n');
+        #12: ABuilder.Append('\f');
+        #13: ABuilder.Append('\r');
         else
-          LBuilder.Append(LChar);
+          ABuilder.Append('\u00').Append(IntToHex(Ord(LChar), 2));
       end;
+      LStart := LFor + 1;
     end;
-    Result := LBuilder.ToString;
-  finally
-    LBuilder.Free;
   end;
+  if LStart = 1 then
+    ABuilder.Append(AValue)
+  else if LStart <= LLen then
+    ABuilder.Append(AValue, LStart - 1, LLen - LStart + 1);
 end;
 
 procedure TJSONSerializer._WriteTValue(const AValue: TValue; ABuilder: TStringBuilder; const AStoreClassName: Boolean);
@@ -781,7 +790,7 @@ begin
     tkChar, tkWChar, tkLString, tkWString, tkUString:
       begin
         ABuilder.Append('"');
-        ABuilder.Append(_EscapeString(AValue.AsString));
+        _AppendEscapedString(AValue.AsString, ABuilder);
         ABuilder.Append('"');
       end;
     tkEnumeration:
@@ -889,7 +898,9 @@ function TJSONSerializer.SerializeToString(AObject: TObject; AStoreClassName: Bo
 var
   LBuilder: TStringBuilder;
 begin
-  LBuilder := TStringBuilder.Create;
+  // Capacidade inicial evita a escada de realocações (16 chars dobrando até
+  // centenas de KB) em documentos grandes; 4KB é irrisório para os pequenos.
+  LBuilder := TStringBuilder.Create(4096);
   try
     _WriteObject(AObject, LBuilder, AStoreClassName);
     Result := LBuilder.ToString;


### PR DESCRIPTION
## Fase 3 da auditoria — foco na serialização

## Mudanças

1. **`_AppendEscapedString`** substitui `_EscapeString`: antes, cada valor string alocava um `TStringBuilder` próprio, fazia append char a char e copiava o resultado para o builder principal. Agora trechos limpos são copiados em bloco direto no destino, e strings sem nada a escapar (caso comum) entram com um único append — zero temporários.
2. **`DateTimeToIso8601`** com escrita direta de dígitos: `FormatDateTime` reparseava a máscara a cada chamada; agora decodifica uma vez e preenche a string pré-dimensionada. Saída idêntica (incluindo a forma só-data).
3. **`TJSONValueString.AsJSON`** com o mesmo fast-path (beneficia o Writer/DOM).
4. **Capacidade inicial de 4KB** no builder do `SerializeToString` — elimina a escada de realocações em documentos grandes.

## Números (mediana de 3, Release Win32, A/B alternado vs fase 2)

| | Serialização | Parse / Deser |
|---|---|---|
| customers-5k | 23 → **16ms** (**-30%**) | inalterados ✓ |
| users-50k | 79 → **68ms** (-13%) | inalterados ✓ |

## Validação

- ✅ Saída **byte-idêntica** (SHA256) nos dois datasets
- ✅ **104/104** testes Schema verdes
- ✅ A/B alternado com exe da fase 2 na mesma condição de máquina

## Acumulado da auditoria (baseline → fase 3)

| | Antes | Agora |
|---|---|---|
| Parse users-50k | ~150.000ms | ~134ms (~1000×) |
| Deser users-50k | 177ms | ~98ms (-45%) |
| Deser customers-5k | 70ms | ~46ms (-34%) |
| Ser customers-5k | 30ms | **~16ms (-47%)** |
| Ser users-50k | 84ms | ~68ms (-19%) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)