### PR TITLE
perf: fase 4 — escrita DOM compacta sem materializar subárvores (-24/-31%)

### DIFF
--- a/Source/JSON/Composition/JsonFlow.Arrays.pas
+++ b/Source/JSON/Composition/JsonFlow.Arrays.pas
@@ -24,7 +24,7 @@ uses
   JsonFlow.Interfaces;
 
 type
-  TJSONArray = class(TInterfacedObject, IJSONElement, IJSONArray)
+  TJSONArray = class(TInterfacedObject, IJSONElement, IJSONArray, IJSONCompactWriter)
   private
     FItems: TList<IJSONElement>;
     function _GetElement(AIndex: Integer; ARaiseOnError: Boolean): IJSONElement;
@@ -40,6 +40,7 @@ type
     function Filter(const APredicate: TFunc<IJSONElement, Boolean>): IJSONArray;
     function Map(const ATransform: TFunc<IJSONElement, IJSONElement>): IJSONArray;
     function Items: TArray<IJSONElement>;
+    procedure AppendCompactJSON(ABuilder: TStringBuilder);
     function AsJSON(const AIdent: Boolean = False): String;
     procedure SaveToStream(AStream: TStream; const AIdent: Boolean = False);
     function Clone: IJSONElement;
@@ -136,12 +137,48 @@ begin
   Result := FItems.ToArray;
 end;
 
+procedure TJSONArray.AppendCompactJSON(ABuilder: TStringBuilder);
+var
+  LFor: Integer;
+  LItem: IJSONElement;
+  LCompact: IJSONCompactWriter;
+begin
+  ABuilder.Append('[');
+  for LFor := 0 to FItems.Count - 1 do
+  begin
+    if LFor > 0 then
+      ABuilder.Append(',');
+    LItem := FItems[LFor];
+    if not Assigned(LItem) then
+      ABuilder.Append(JSON_NULL)
+    else if Supports(LItem, IJSONCompactWriter, LCompact) then
+      LCompact.AppendCompactJSON(ABuilder)
+    else
+      ABuilder.Append(LItem.AsJSON(False));
+  end;
+  ABuilder.Append(']');
+end;
+
 function TJSONArray.AsJSON(const AIdent: Boolean): String;
 var
   LBuilder: TStringBuilder;
   LFor: Integer;
   LIndent: String;
 begin
+  // Compacto: recursão num único builder — antes cada item materializava a
+  // subárvore inteira como String.
+  if not AIdent then
+  begin
+    LBuilder := TStringBuilder.Create(1024);
+    try
+      AppendCompactJSON(LBuilder);
+      Result := LBuilder.ToString;
+    finally
+      LBuilder.Free;
+    end;
+    Exit;
+  end;
+
   LBuilder := TStringBuilder.Create;
   try
     if AIdent then

--- a/Source/JSON/Composition/JsonFlow.Objects.pas
+++ b/Source/JSON/Composition/JsonFlow.Objects.pas
@@ -26,7 +26,7 @@ uses
   JsonFlow.Pair;
 
 type
-  TJSONObject = class(TInterfacedObject, IJSONElement, IJSONObject)
+  TJSONObject = class(TInterfacedObject, IJSONElement, IJSONObject, IJSONCompactWriter)
   private const
     // Abaixo disso a varredura linear é mais barata que manter o dicionário
     // (objetos JSON típicos têm poucas chaves e não pagam alocação extra).
@@ -50,6 +50,7 @@ type
     function Filter(const APredicate: TFunc<String, IJSONElement, Boolean>): IJSONObject;
     function Map(const ATransform: TFunc<String, IJSONElement, IJSONPair>): IJSONObject;
     function Pairs: TArray<IJSONPair>;
+    procedure AppendCompactJSON(ABuilder: TStringBuilder);
     function AsJSON(const AIdent: Boolean = False): String;
     procedure SaveToStream(AStream: TStream; const AIdent: Boolean = False);
     function Clone: IJSONElement;
@@ -270,12 +271,51 @@ begin
   Result := FPairs.ToArray;
 end;
 
+procedure TJSONObject.AppendCompactJSON(ABuilder: TStringBuilder);
+var
+  LFor: Integer;
+  LValue: IJSONElement;
+  LCompact: IJSONCompactWriter;
+begin
+  ABuilder.Append('{');
+  for LFor := 0 to FPairs.Count - 1 do
+  begin
+    if LFor > 0 then
+      ABuilder.Append(',');
+    ABuilder.Append('"');
+    ABuilder.Append(StringReplace(FPairs[LFor].Key, '"', '\"', [rfReplaceAll]));
+    ABuilder.Append('":');
+    LValue := FPairs[LFor].Value;
+    if not Assigned(LValue) then
+      ABuilder.Append(JSON_NULL)
+    else if Supports(LValue, IJSONCompactWriter, LCompact) then
+      LCompact.AppendCompactJSON(ABuilder)
+    else
+      ABuilder.Append(LValue.AsJSON(False));
+  end;
+  ABuilder.Append('}');
+end;
+
 function TJSONObject.AsJSON(const AIdent: Boolean): String;
 var
   LBuilder: TStringBuilder;
   LFor: Integer;
   LIndent: String;
 begin
+  // Compacto: recursão num único builder — antes cada nível materializava a
+  // subárvore inteira como String (Pair.AsJSON -> Value.AsJSON -> ...).
+  if not AIdent then
+  begin
+    LBuilder := TStringBuilder.Create(1024);
+    try
+      AppendCompactJSON(LBuilder);
+      Result := LBuilder.ToString;
+    finally
+      LBuilder.Free;
+    end;
+    Exit;
+  end;
+
   LBuilder := TStringBuilder.Create;
   try
     if AIdent then

--- a/Source/JSON/Core/JsonFlow.Interfaces.pas
+++ b/Source/JSON/Core/JsonFlow.Interfaces.pas
@@ -142,6 +142,16 @@ type
     function Value(AIndex: Integer): IJSONElement;
   end;
 
+  /// <summary>
+  /// Caminho interno de escrita compacta: objetos/arrays recursam no mesmo
+  /// TStringBuilder em vez de materializar cada subárvore como String
+  /// intermediária (custo O(tamanho × profundidade) no AsJSON/Writer).
+  /// </summary>
+  IJSONCompactWriter = interface
+    ['{7D6E9F2A-3B1C-4D5E-8A9B-0C1D2E3F4A5B}']
+    procedure AppendCompactJSON(ABuilder: TStringBuilder);
+  end;
+
   IJSONWriter = interface
     ['{89F0EE05-38B8-44EA-BA7D-81623545D5E4}']
     function Write(const AElement: IJSONElement; const AIdent: Boolean = False): String;

--- a/Source/JSON/IO/JsonFlow.Writer.pas
+++ b/Source/JSON/IO/JsonFlow.Writer.pas
@@ -80,10 +80,19 @@ var
   LPairs: TArray<IJSONPair>;
   LArr: IJSONArray;
   LItems: TArray<IJSONElement>;
+  LCompact: IJSONCompactWriter;
 begin
   if not Assigned(AElement) then
   begin
     ABuilder.Append(JSON_NULL);
+    Exit;
+  end;
+
+  // Compacto: recursão num único builder — antes cada par materializava a
+  // subárvore inteira como String (Pair.AsJSON -> Value.AsJSON -> ...).
+  if (not AIdent) and Supports(AElement, IJSONCompactWriter, LCompact) then
+  begin
+    LCompact.AppendCompactJSON(ABuilder);
     Exit;
   end;
 
@@ -149,7 +158,7 @@ function TJSONWriter.Write(const AElement: IJSONElement; const AIdent: Boolean):
 var
   LBuilder: TStringBuilder;
 begin
-  LBuilder := TStringBuilder.Create;
+  LBuilder := TStringBuilder.Create(4096);
   try
     _WriteElement(AElement, LBuilder, AIdent, 0);
     Result := LBuilder.ToString;


### PR DESCRIPTION
## Fase 4 (final) da auditoria de performance

Os caminhos DOM→string (`TJSONWriter.Write` e `element.AsJSON`) montavam o JSON de **cada nó como String intermediária** e copiavam para o builder do pai — custo O(tamanho × profundidade), mais um `StringReplace` por chave via `Pair.AsJSON`.

## Mudanças

1. Nova interface interna **`IJSONCompactWriter`** (`AppendCompactJSON(Builder)`) em `JsonFlow.Interfaces`.
2. `TJSONObject`/`TJSONArray` implementam o walker; o `AsJSON` **compacto** delega à recursão num único builder. Folhas caem no `AsJSON(False)` normal (uma string pequena por folha).
3. `TJSONWriter._WriteElement` curto-circuita para o walker quando não identado. **Pretty-print mantém o caminho e formato legados intactos.**
4. Capacidade inicial de 4KB no builder do `Writer.Write`.

## Números (mediana de 3, Release Win32, A/B alternado vs fase 3)

| Escrita DOM compacta | Fase 3 | Fase 4 |
|---|---|---|
| users-50k | 50ms | **38ms (-24%)** |
| customers-5k | 39ms | **27ms (-31%)** |

Parse / Deser / Ser direto: inalterados ✓

## Validação

- ✅ Saída **byte-idêntica** (SHA256) para `Writer.Write` **e** `element.AsJSON` nos dois datasets
- ✅ Harness principal sem regressão (saídas idênticas)
- ✅ **104/104** testes Schema verdes

## 🏁 Fecha a auditoria — acumulado baseline → fase 4

| Caminho | Antes | Depois |
|---|---|---|
| Parse users-50k | ~150.000ms | ~125ms (**~1000×**) |
| Parse customers-5k | ~620ms | ~90ms (~6×) |
| Deser users-50k | 177ms | ~93ms (**-47%**) |
| Deser customers-5k | 70ms | ~46ms (**-34%**) |
| Ser customers-5k | 30ms | ~17ms (**-43%**) |
| Ser users-50k | 84ms | ~67ms (**-20%**) |
| DOM write users-50k | ~51ms* | ~38ms (**-25%**) |

\* DOM write medido a partir da fase 3 (antes disso o parse O(n²) impedia medição limpa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)