### PR TITLE
fix: Fase A — 8 bugs de correção da auditoria de recursos

### DIFF
--- a/Source/Core/JsonFlow.Builders.pas
+++ b/Source/Core/JsonFlow.Builders.pas
@@ -120,7 +120,13 @@ type
   strict private
     class var FNotifyEventSetValue: TNotifyEventSetValue;
     class var FNotifyEventGetValue: TNotifyEventGetValue;
-    class var FMiddlwareList: TList<IEventMiddleware>;
+    // Snapshot imutável: mutações (AddMiddleware/ClearMiddlewares) trocam o
+    // array inteiro sob lock; leitores iteram a referência local sem lock.
+    // Registre middlewares na inicialização — antes de haver serializações
+    // concorrentes (o TList anterior era iterado e mutado sem sincronização,
+    // corrompendo o enumerador em servidores multi-thread como o Horse).
+    class var FMiddlwareList: TArray<IEventMiddleware>;
+    class var FMiddlwareLock: TObject;
   strict private
     class function _ResolveValueArrayString(const AValue: Variant): TArray<String>; inline;
     class function _ResolveValueArrayInteger(const AValue: Variant): TArray<Integer>; inline;
@@ -371,7 +377,10 @@ begin
           if L_IsBoolean() then
             Result := AProperty.GetValue(AInstance).AsBoolean
           else
-            Result := GetEnumValue(LTypeInfo, AProperty.GetValue(AInstance).AsString) >= 0;
+            // Serializa o NOME do enum — a expressão anterior
+            // (GetEnumValue(...) >= 0) devolvia um Boolean, então todo enum
+            // não-boolean saía como "true" no JSON.
+            Result := GetEnumName(LTypeInfo, AProperty.GetValue(AInstance).AsOrdinal);
         end;
       tkArray, tkDynArray:
         begin
@@ -429,6 +438,7 @@ var
   LMiddleware: IEventMiddleware;
   LSetMw: ISetValueMiddleware;
   LValue: Variant;
+  LIntValue: Integer;
 
   function L_IsBoolean: Boolean;
   var
@@ -470,8 +480,11 @@ begin
           AProperty.SetValue(AInstance, TValue.From<String>(''))
         else
           AProperty.SetValue(AInstance, TValue.From<String>(LValue));
-      tkInteger, tkSet, tkInt64:
+      tkInteger, tkSet:
         AProperty.SetValue(AInstance, TValue.From<Integer>(LValue));
+      tkInt64:
+        // Caso separado do tkInteger: o From<Integer> truncava Int64 em 32 bits
+        AProperty.SetValue(AInstance, TValue.From<Int64>(LValue));
       tkFloat:
         if TVarData(LValue).VType <= varNull then
           AProperty.SetValue(AInstance, TValue.From<Double>(0.0))
@@ -495,8 +508,16 @@ begin
         begin
           if L_IsBoolean() then
             AProperty.SetValue(AInstance, TValue.From<Boolean>(LValue))
+          else if VarIsNumeric(LValue) then
+            AProperty.SetValue(AInstance, TValue.FromOrdinal(LTypeInfo, LValue))
           else
-            AProperty.SetValue(AInstance, TValue.FromVariant(LValue));
+          begin
+            // Aceita o NOME do enum (par do fix na serialização) — o
+            // FromVariant anterior gerava EInvalidCast com valor string.
+            LIntValue := GetEnumValue(LTypeInfo, VarToStr(LValue));
+            if LIntValue >= 0 then
+              AProperty.SetValue(AInstance, TValue.FromOrdinal(LTypeInfo, LIntValue));
+          end;
         end;
       tkArray, tkDynArray:
         begin
@@ -514,22 +535,34 @@ end;
 procedure TJsonBuilder.AddMiddleware(
   const AEventMiddleware: IEventMiddleware);
 begin
-  FMiddlwareList.Add(AEventMiddleware);
+  TMonitor.Enter(FMiddlwareLock);
+  try
+    FMiddlwareList := FMiddlwareList + [AEventMiddleware];
+  finally
+    TMonitor.Exit(FMiddlwareLock);
+  end;
 end;
 
 class constructor TJsonBuilder.Create;
 begin
-  FMiddlwareList := TList<IEventMiddleware>.Create;
+  FMiddlwareLock := TObject.Create;
+  FMiddlwareList := nil;
 end;
 
 class destructor TJsonBuilder.Destroy;
 begin
-  FMiddlwareList.Free;
+  FMiddlwareList := nil;
+  FMiddlwareLock.Free;
 end;
 
 class procedure TJsonBuilder.ClearMiddlewares;
 begin
-  FMiddlwareList.Clear;
+  TMonitor.Enter(FMiddlwareLock);
+  try
+    FMiddlwareList := nil;
+  finally
+    TMonitor.Exit(FMiddlwareLock);
+  end;
 end;
 
 function TJsonBuilder.DynArrayDoubleToJson(const AValue: TValue): String;
@@ -624,7 +657,10 @@ begin
     LItem := AType.Create;
     if not _JsonVariantData(LData.FJsonPair.Values[LFor]).ToObject(LItem) then
     begin
-      Result.Free;
+      // FreeAndNil + Free do item corrente: o Free simples deixava o chamador
+      // com ponteiro dangling e vazava o item ainda não adicionado à lista.
+      LItem.Free;
+      FreeAndNil(Result);
       Exit;
     end;
     Result.Add(LItem);
@@ -649,7 +685,10 @@ begin
     LItem := T.Create;
     if not _JsonVariantData(LData.FJsonPair.Values[LFor]).ToObject(LItem) then
     begin
-      Result.Free;
+      // FreeAndNil + Free do item corrente: o Free simples deixava o chamador
+      // com ponteiro dangling e vazava o item ainda não adicionado à lista.
+      LItem.Free;
+      FreeAndNil(Result);
       Exit;
     end;
     Result.Add(LItem);
@@ -672,8 +711,14 @@ end;
 function TJsonBuilder.JsonToObject<T>(const AJson: String): T;
 begin
   Result := T.Create;
-  if not JsonToObject(TObject(Result), AJson) then
-    raise Exception.Create('Error JSON to Object');
+  try
+    if not JsonToObject(TObject(Result), AJson) then
+      raise Exception.Create('Error JSON to Object');
+  except
+    // Sem o try/except a instância recém-criada vazava quando o parse falhava
+    Result.Free;
+    raise;
+  end;
 end;
 
 function TJsonBuilder.ObjectToJson(const AObject: TObject;

--- a/Source/JSON/IO/JsonFlow.Reader.pas
+++ b/Source/JSON/IO/JsonFlow.Reader.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -34,26 +34,15 @@ type
   private
     FLogProc: TProc<String>;
     FFormatSettings: TFormatSettings;
-    FBuffer: TCharArray;
     FBufferSize: Integer;
-    FBufferPos: Integer;
-    FBufferEnd: Integer;
-    FStream: TStream;
     FProgressProc: TProc<TObject, Single>;
     procedure _Log(const AMessage: string);
-    procedure _SkipWhitespace(const AJson: PChar; var AIndex: Integer; ALength: Integer); overload;
-    procedure _SkipWhitespace(var AChar: Char; AStream: TStream); overload;
-    function _ParseValue(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONElement; overload;
-    function _ParseValue(var AChar: Char; AStream: TStream): IJSONElement; overload;
-    function _ParseObject(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONObject; overload;
-    function _ParseObject(var AChar: Char; AStream: TStream): IJSONObject; overload;
-    function _ParseArray(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONArray; overload;
-    function _ParseArray(var AChar: Char; AStream: TStream): IJSONArray; overload;
-    function _ParseString(const AJson: PChar; var AIndex: Integer; ALength: Integer): String; overload;
-    function _ParseString(var AChar: Char; AStream: TStream): String; overload;
-    function _ParseNumber(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONElement; overload;
-    function _ParseNumber(var AChar: Char; AStream: TStream): IJSONElement; overload;
-    function _ReadChar(AStream: TStream; var AChar: Char): Boolean;
+    procedure _SkipWhitespace(const AJson: PChar; var AIndex: Integer; ALength: Integer);
+    function _ParseValue(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONElement;
+    function _ParseObject(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONObject;
+    function _ParseArray(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONArray;
+    function _ParseString(const AJson: PChar; var AIndex: Integer; ALength: Integer): String;
+    function _ParseNumber(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONElement;
   public
     constructor Create; overload;
     constructor Create(const ABufferSize: Integer); overload;
@@ -75,7 +64,6 @@ begin
   FFormatSettings := TFormatSettings.Create('en_US');
   FFormatSettings.DecimalSeparator := '.';
   FBufferSize := 65536;
-  SetLength(FBuffer, FBufferSize);
 end;
 
 constructor TJSONReader.Create(const ABufferSize: Integer);
@@ -84,15 +72,9 @@ begin
   if ABufferSize <= 0 then
     Exit;
   if ABufferSize < 4096 then
-  begin
-    FBufferSize := 4096;
-    SetLength(FBuffer, FBufferSize);
-  end
+    FBufferSize := 4096
   else
-  begin
     FBufferSize := ABufferSize;
-    SetLength(FBuffer, FBufferSize);
-  end;
 end;
 
 constructor TJSONReader.Create(const AFormatSettings: TFormatSettings);
@@ -105,10 +87,7 @@ constructor TJSONReader.Create(const AFormatSettings: TFormatSettings; const ABu
 begin
   Create(AFormatSettings);
   if ABufferSize > 0 then
-  begin
     FBufferSize := ABufferSize;
-    SetLength(FBuffer, FBufferSize);
-  end;
 end;
 
 procedure TJSONReader.OnLog(const ALogProc: TProc<String>);
@@ -121,40 +100,10 @@ begin
   FProgressProc := AProgress;
 end;
 
-function TJSONReader._ReadChar(AStream: TStream; var AChar: Char): Boolean;
-var
-  LProgress: Single;
-begin
-  if FBufferPos >= FBufferEnd then
-  begin
-    FBufferEnd := AStream.Read(FBuffer[0], FBufferSize * SizeOf(Char));
-    FBufferPos := 0;
-    if FBufferEnd = 0 then
-    begin
-      Result := False;
-      Exit;
-    end;
-    _Log('Read ' + IntToStr(FBufferEnd) + ' bytes into buffer (size: ' + IntToStr(FBufferSize) + ')');
-    if Assigned(FProgressProc) and (AStream.Size > 0) then
-    begin
-      LProgress := (AStream.Position / AStream.Size) * 100;
-      FProgressProc(Self, LProgress);
-    end;
-  end;
-  AChar := FBuffer[FBufferPos];
-  Inc(FBufferPos);
-  Result := True;
-end;
-
 procedure TJSONReader._SkipWhitespace(const AJson: PChar; var AIndex: Integer; ALength: Integer);
 begin
   while (AIndex < ALength) and CharInSet(AJson[AIndex], [#9, #10, #13, #32]) do
     Inc(AIndex);
-end;
-
-procedure TJSONReader._SkipWhitespace(var AChar: Char; AStream: TStream);
-begin
-  while CharInSet(AChar, [#9, #10, #13, #32]) and _ReadChar(AStream, AChar) do;
 end;
 
 function TJSONReader._ParseString(const AJson: PChar; var AIndex: Integer; ALength: Integer): String;
@@ -209,53 +158,6 @@ begin
   end;
 end;
 
-function TJSONReader._ParseString(var AChar: Char; AStream: TStream): String;
-var
-  LBuilder: TStringBuilder;
-begin
-  LBuilder := TStringBuilder.Create;
-  try
-    while _ReadChar(AStream, AChar) do
-    begin
-      if AChar = '"' then
-      begin
-        Result := LBuilder.ToString;
-        Exit;
-      end;
-      if AChar = '\' then
-      begin
-        if not _ReadChar(AStream, AChar) then
-          raise EJsonFlowParseError.Create('Unexpected end of JSON string');
-        case AChar of
-          '"', '\', '/': LBuilder.Append(AChar);
-          'b': LBuilder.Append(#8);
-          'f': LBuilder.Append(#12);
-          'n': LBuilder.Append(#10);
-          'r': LBuilder.Append(#13);
-          't': LBuilder.Append(#9);
-          'u': begin
-                 var LUnicode: string := '';
-                 for var i := 1 to 4 do
-                 begin
-                   if not _ReadChar(AStream, AChar) then
-                     raise EJsonFlowParseError.Create('Invalid unicode escape');
-                   LUnicode := LUnicode + AChar;
-                 end;
-                 LBuilder.Append(Char(StrToInt('$'+LUnicode)));
-               end;
-          else
-            raise EJsonFlowParseError.Create('Invalid escape sequence');
-        end;
-      end
-      else
-        LBuilder.Append(AChar);
-    end;
-    raise EJsonFlowParseError.Create('Unterminated string');
-  finally
-    LBuilder.Free;
-  end;
-end;
-
 function TJSONReader._ParseNumber(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONElement;
 var
   LStart: Integer;
@@ -273,25 +175,6 @@ begin
   // SetString copia só o trecho do número — Copy(AJson, ...) com PChar
   // convertia o restante inteiro do buffer para String a cada número (O(n²)).
   SetString(LStr, AJson + LStart, AIndex - LStart);
-  if LIsFloat then
-    Result := TJSONValueFloat.Create(StrToFloatDef(LStr, 0.0, FFormatSettings))
-  else
-    Result := TJSONValueInteger.Create(StrToInt64Def(LStr, 0));
-end;
-
-function TJSONReader._ParseNumber(var AChar: Char; AStream: TStream): IJSONElement;
-var
-  LStr: string;
-  LIsFloat: Boolean;
-begin
-  LStr := AChar;
-  LIsFloat := False;
-  while _ReadChar(AStream, AChar) and CharInSet(AChar, ['0'..'9', '-', '.', 'e', 'E', '+']) do
-  begin
-    LStr := LStr + AChar;
-    if CharInSet(AChar, ['.', 'e', 'E']) then
-      LIsFloat := True;
-  end;
   if LIsFloat then
     Result := TJSONValueFloat.Create(StrToFloatDef(LStr, 0.0, FFormatSettings))
   else
@@ -385,58 +268,6 @@ begin
   end;
 end;
 
-function TJSONReader._ParseValue(var AChar: Char; AStream: TStream): IJSONElement;
-var
-  LValue: TJSONValue;
-  LString: String;
-
-  function _IsISODateTime_(const S: String): Boolean;
-  begin
-    Result := (Length(S) >= 10) and (S[5] = '-') and (S[8] = '-') and
-              CharInSet(S[1], ['0'..'9']) and CharInSet(S[2], ['0'..'9']) and
-              CharInSet(S[3], ['0'..'9']) and CharInSet(S[4], ['0'..'9']);
-    if Result and (Pos('T', S) > 0) then
-      Result := (Length(S) >= 19) and CharInSet(S[12], ['0'..'2']) and CharInSet(S[15], ['0'..'5']);
-  end;
-
-begin
-  _SkipWhitespace(AChar, AStream);
-  case AChar of
-    '{': Result := _ParseObject(AChar, AStream);
-    '[': Result := _ParseArray(AChar, AStream);
-    '"': begin
-           LString := _ParseString(AChar, AStream);
-           if _IsISODateTime_(LString) then
-             LValue := TJSONValueDateTime.Create(LString, True)
-           else
-             LValue := TJSONValueString.Create(LString);
-           Result := LValue;
-           if not _ReadChar(AStream, AChar) then AChar := #0;
-         end;
-    't': begin
-           LValue := TJSONValueBoolean.Create(True);
-           Result := LValue;
-           for var i := 1 to 3 do if not _ReadChar(AStream, AChar) then
-             raise EJsonFlowParseError.Create('Incomplete true value');
-         end;
-    'f': begin
-           LValue := TJSONValueBoolean.Create(False);
-           Result := LValue;
-           for var i := 1 to 4 do if not _ReadChar(AStream, AChar) then
-             raise EJsonFlowParseError.Create('Incomplete false value');
-         end;
-    'n': begin
-           LValue := TJSONValueNull.Create;
-           Result := LValue;
-           for var i := 1 to 3 do if not _ReadChar(AStream, AChar) then
-             raise EJsonFlowParseError.Create('Incomplete null value');
-         end;
-    '0'..'9', '-': Result := _ParseNumber(AChar, AStream);
-    else
-      raise EJsonFlowParseError.Create('Unexpected character: ' + AChar);
-  end;
-end;
-
 function TJSONReader._ParseObject(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONObject;
 var
   LKey: String;
@@ -479,40 +310,6 @@ begin
   end;
 end;
 
-function TJSONReader._ParseObject(var AChar: Char; AStream: TStream): IJSONObject;
-var
-  LKey: String;
-begin
-  Result := TJSONObject.Create;
-  if not _ReadChar(AStream, AChar) then
-    raise EJsonFlowParseError.Create('Unterminated object');
-  _SkipWhitespace(AChar, AStream);
-
-  if AChar = '}' then Exit;
-
-  while True do
-  begin
-    if AChar <> '"' then
-      raise EJsonFlowParseError.Create('Expected string key');
-    LKey := _ParseString(AChar, AStream);
-    if not _ReadChar(AStream, AChar) then
-      raise EJsonFlowParseError.Create('Expected ":" after key');
-    _SkipWhitespace(AChar, AStream);
-    if AChar <> ':' then
-      raise EJsonFlowParseError.Create('Expected ":" after key');
-    if not _ReadChar(AStream, AChar) then
-      raise EJsonFlowParseError.Create('Unexpected end of JSON');
-    Result.Add(LKey, _ParseValue(AChar, AStream));
-    _SkipWhitespace(AChar, AStream);
-    if AChar = '}' then Break;
-    if AChar <> ',' then
-      raise EJsonFlowParseError.Create('Expected "," or "}"');
-    if not _ReadChar(AStream, AChar) then
-      raise EJsonFlowParseError.Create('Unterminated object');
-  end;
-  if not _ReadChar(AStream, AChar) then AChar := #0;
-end;
-
 function TJSONReader._ParseArray(const AJson: PChar; var AIndex: Integer; ALength: Integer): IJSONArray;
 begin
   Result := TJSONArray.Create;
@@ -543,28 +340,6 @@ begin
   end;
 end;
 
-function TJSONReader._ParseArray(var AChar: Char; AStream: TStream): IJSONArray;
-begin
-  Result := TJSONArray.Create;
-  if not _ReadChar(AStream, AChar) then
-    raise EJsonFlowParseError.Create('Unterminated array');
-  _SkipWhitespace(AChar, AStream);
-
-  if AChar = ']' then Exit;
-
-  while True do
-  begin
-    Result.Add(_ParseValue(AChar, AStream));
-    _SkipWhitespace(AChar, AStream);
-    if AChar = ']' then Break;
-    if AChar <> ',' then
-      raise EJsonFlowParseError.Create('Expected "," or "]"');
-    if not _ReadChar(AStream, AChar) then
-      raise EJsonFlowParseError.Create('Unterminated array');
-  end;
-  if not _ReadChar(AStream, AChar) then AChar := #0;
-end;
-
 function TJSONReader.Read(const AJson: String): IJSONElement;
 var
   LIndex: Integer;
@@ -580,15 +355,32 @@ end;
 
 function TJSONReader.ReadFromStream(AStream: TStream): IJSONElement;
 var
-  LChar: Char;
+  LBytes: TBytes;
+  LCount: Int64;
+  LEncoding: TEncoding;
+  LOffset: Integer;
+  LJson: string;
 begin
-  FStream := AStream;
-  FBufferPos := 0;
-  FBufferEnd := 0;
-  if not _ReadChar(AStream, LChar) then
+  // O parser de stream anterior tinha dois defeitos fatais: usava o retorno de
+  // AStream.Read (BYTES) como índice de CHARS (leitura fora do buffer em
+  // documentos > buffer) e assumia UTF-16 cru, enquanto todo SaveToStream do
+  // framework grava UTF-8. Agora: lê os bytes, detecta BOM (UTF-8/16/32,
+  // default UTF-8) e decodifica antes de delegar ao parser PChar otimizado.
+  LCount := AStream.Size - AStream.Position;
+  if LCount <= 0 then
     raise EJsonFlowParseError.Create('Empty stream');
-  _SkipWhitespace(LChar, AStream);
-  Result := _ParseValue(LChar, AStream);
+
+  SetLength(LBytes, LCount);
+  AStream.ReadBuffer(LBytes[0], LCount);
+
+  LEncoding := nil;
+  LOffset := TEncoding.GetBufferEncoding(LBytes, LEncoding, TEncoding.UTF8);
+  LJson := LEncoding.GetString(LBytes, LOffset, Length(LBytes) - LOffset);
+
+  if Assigned(FProgressProc) then
+    FProgressProc(Self, 100);
+
+  Result := Read(LJson);
 end;
 
 procedure TJSONReader._Log(const AMessage: string);

--- a/Source/JsonFlow.pas
+++ b/Source/JsonFlow.pas
@@ -174,6 +174,9 @@ end;
 
 class procedure TJsonFlow._SetFormatSettings(const Value: TFormatSettings);
 begin
+  // ATENÇÃO: configuração GLOBAL sem sincronização — defina apenas na
+  // inicialização da aplicação, antes de haver serializações concorrentes
+  // (o record contém strings; escrita simultânea a leituras é race condition).
   GJsonFlowFormatSettings := Value;
 end;
 
@@ -208,7 +211,9 @@ begin
       if LFor < AObjectList.Count - 1 then
         LResultBuilder.Append(',');
     end;
-    LResultBuilder.ReplaceLastChar(']');
+    // Append em vez de ReplaceLastChar: o replace sobrescrevia o '}' final do
+    // último objeto, corrompendo a saída ('[{"a":1]'); lista vazia vira '[]'.
+    LResultBuilder.Append(']');
     Result := LResultBuilder.ToString;
   finally
     LResultBuilder.Free;
@@ -230,7 +235,9 @@ begin
       if LFor < AObjectList.Count - 1 then
         LResultBuilder.Append(',');
     end;
-    LResultBuilder.ReplaceLastChar(']');
+    // Append em vez de ReplaceLastChar: o replace sobrescrevia o '}' final do
+    // último objeto, corrompendo a saída ('[{"a":1]'); lista vazia vira '[]'.
+    LResultBuilder.Append(']');
     Result := LResultBuilder.ToString;
   finally
     LResultBuilder.Free;

--- a/Source/Schema/Validators/JsonFlow.FormatRegistry.pas
+++ b/Source/Schema/Validators/JsonFlow.FormatRegistry.pas
@@ -64,6 +64,9 @@ type
   private
     class var FInstance: TFormatRegistry;
     class var FValidators: TDictionary<string, IFormatValidator>;
+    // Protege o dicionário: registro/consulta concorrentes (validações em
+    // threads distintas) corrompiam o TDictionary sem sincronização.
+    class var FLock: TObject;
     class constructor Create;
     class destructor Destroy;
     constructor Create;
@@ -174,13 +177,18 @@ end;
 
 class constructor TFormatRegistry.Create;
 begin
+  FLock := TObject.Create;
   FValidators := TDictionary<string, IFormatValidator>.Create;
+  // Instância criada aqui (eager) para eliminar o lazy-init com race no Instance
+  FInstance := TFormatRegistry.Create;
   RegisterBuiltInFormatValidators;
 end;
 
 class destructor TFormatRegistry.Destroy;
 begin
+  FInstance.Free;
   FValidators.Free;
+  FLock.Free;
 end;
 
 constructor TFormatRegistry.Create;
@@ -190,52 +198,68 @@ end;
 
 class function TFormatRegistry.Instance: TFormatRegistry;
 begin
-  if not Assigned(FInstance) then
-    FInstance := TFormatRegistry.Create;
   Result := FInstance;
 end;
 
 class procedure TFormatRegistry.RegisterValidator(const AFormatName: string; const AValidator: IFormatValidator);
-var
-  LFormatLower: string;
 begin
-  LFormatLower := AnsiLowerCase(AFormatName);
-  FValidators.AddOrSetValue(LFormatLower, AValidator);
+  TMonitor.Enter(FLock);
+  try
+    FValidators.AddOrSetValue(AnsiLowerCase(AFormatName), AValidator);
+  finally
+    TMonitor.Exit(FLock);
+  end;
 end;
 
 class procedure TFormatRegistry.UnregisterValidator(const AFormatName: string);
-var
-  LFormatLower: string;
 begin
-  LFormatLower := AnsiLowerCase(AFormatName);
-  FValidators.Remove(LFormatLower);
+  TMonitor.Enter(FLock);
+  try
+    FValidators.Remove(AnsiLowerCase(AFormatName));
+  finally
+    TMonitor.Exit(FLock);
+  end;
 end;
 
 class function TFormatRegistry.GetValidator(const AFormatName: string): IFormatValidator;
-var
-  LFormatLower: string;
 begin
-  LFormatLower := AnsiLowerCase(AFormatName);
-  if not FValidators.TryGetValue(LFormatLower, Result) then
-    Result := nil;
+  TMonitor.Enter(FLock);
+  try
+    if not FValidators.TryGetValue(AnsiLowerCase(AFormatName), Result) then
+      Result := nil;
+  finally
+    TMonitor.Exit(FLock);
+  end;
 end;
 
 class function TFormatRegistry.IsFormatRegistered(const AFormatName: string): Boolean;
-var
-  LFormatLower: string;
 begin
-  LFormatLower := AnsiLowerCase(AFormatName);
-  Result := FValidators.ContainsKey(LFormatLower);
+  TMonitor.Enter(FLock);
+  try
+    Result := FValidators.ContainsKey(AnsiLowerCase(AFormatName));
+  finally
+    TMonitor.Exit(FLock);
+  end;
 end;
 
 class function TFormatRegistry.GetRegisteredFormats: TArray<string>;
 begin
-  Result := FValidators.Keys.ToArray;
+  TMonitor.Enter(FLock);
+  try
+    Result := FValidators.Keys.ToArray;
+  finally
+    TMonitor.Exit(FLock);
+  end;
 end;
 
 class procedure TFormatRegistry.ClearRegistry;
 begin
-  FValidators.Clear;
+  TMonitor.Enter(FLock);
+  try
+    FValidators.Clear;
+  finally
+    TMonitor.Exit(FLock);
+  end;
 end;
 
 { TEmailFormatValidator }

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.UniqueItems.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.UniqueItems.pas
@@ -64,10 +64,12 @@ begin
     else
       Result := 'unknown';
   end
+  // Serialização compacta real: os placeholders '[array]'/'{object}' faziam
+  // QUALQUER par de arrays/objetos distintos contar como duplicado.
   else if Supports(AElement, IJSONArray, LArray) then
-    Result := '[array]' // Simplificação - seria necessário serializar o array completo
+    Result := LArray.AsJSON(False)
   else if Supports(AElement, IJSONObject, LObject) then
-    Result := '{object}' // Simplificação - seria necessário serializar o objeto completo
+    Result := LObject.AsJSON(False)
   else
     Result := 'unknown';
 end;


### PR DESCRIPTION
## Fase A da auditoria de recursos (navegação/edição/schema/middlewares/read-write POO)

Só correção de comportamento — nenhuma mudança de formato de saída (harness de perf **byte-idêntico** ao main).

## Os 8 fixes

| # | Bug | Efeito antes |
|---|---|---|
| 1 | `ObjectListToJsonString` (2 overloads): `ReplaceLastChar(']')` sobrescrevia o `}` final | JSON corrompido: `[{\"a\":1]` |
| 2 | Middlewares em `class var TList` sem lock, iterado por propriedade | AV/corrupção sob concorrência (Horse) — agora snapshot imutável trocado sob `TMonitor` |
| 3 | Enum no `TJsonBuilder` serializava `GetEnumValue(...)>=0` | **Todo enum saía como `true`**; agora sai o nome, e a deserialização aceita nome ou ordinal |
| 4 | `tkInt64` deserializado via `From<Integer>` | Truncava em 32 bits |
| 5 | `JsonToObjectList` em falha: `Result.Free + Exit` | **Ponteiro dangling** no chamador + leak do item; `JsonToObject<T>` vazava a instância |
| 6 | `ReadFromStream`: contagem de **bytes** usada como índice de **chars** + assumia UTF-16 cru | Out-of-bounds em docs >64K chars; incompatível com o `SaveToStream` (UTF-8). Reescrito com detecção de BOM (`TEncoding`), default UTF-8, delegando ao parser PChar otimizado. ~200 linhas de parser de stream morto removidas + 128KB/instância economizados |
| 7 | `uniqueItems`: objetos/arrays distintos colapsavam em `'{object}'`/`'[array]'` | **Falsos duplicados** reprovavam documentos válidos; agora compara `AsJSON` compacto |
| 8 | `TFormatRegistry`: dict `class var` sem lock + singleton lazy com race | Corrupção em validações concorrentes; agora tudo sob `TMonitor`, instância eager |

\+ restrição documentada no setter global de `TJsonFlow.FormatSettings`.

## Validação

- ✅ **15/15** testes de regressão novos (console): lista→JSON válido/vazia, enum nome + round-trip, Int64 4GB round-trip, caminho de falha sem dangling, stream UTF-8 com/sem BOM + doc de 555KB, uniqueItems com distintos/iguais, smoke 4 threads × 2000 serializações
- ✅ **104/104** testes Schema
- ✅ Harness de perf: números estáveis e saída **byte-idêntica** (SHA256) ao main

🤖 Generated with [Claude Code](https://claude.com/claude-code)