### PR TITLE
perf: Fase B — validação Schema 3,1× mais rápida

### DIFF
--- a/Source/Schema/Validators/JsonFlow.FormatRegistry.pas
+++ b/Source/Schema/Validators/JsonFlow.FormatRegistry.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -34,6 +34,7 @@ interface
 uses
   System.SysUtils,
   System.Classes,
+  System.RegularExpressions,
   System.Generics.Collections;
 
 type
@@ -80,59 +81,59 @@ type
     class procedure ClearRegistry;
   end;
 
+  // Base para validadores de regex fixa: compila o padrão UMA vez no
+  // constructor (os validadores são singletons de vida longa no registry;
+  // antes cada DoValidate criava e compilava um TRegEx novo por valor).
+  TRegexFormatValidator = class(TBaseFormatValidator)
+  private
+    FRegex: TRegEx;
+  protected
+    function DoValidate(const AValue: string): Boolean; override;
+  public
+    constructor Create(const AFormatName, APattern: string);
+  end;
+
   // Validadores built-in usando o novo sistema
-  TEmailFormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TEmailFormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
 
-  TUriFormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TUriFormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
 
-  TDateFormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TDateFormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
 
-  TTimeFormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TTimeFormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
 
   TDateTimeFormatValidator = class(TBaseFormatValidator)
+  private
+    FRegex: TRegEx;
   protected
     function DoValidate(const AValue: string): Boolean; override;
   public
     constructor Create;
   end;
 
-  TUuidFormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TUuidFormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
 
-  TIpv4FormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TIpv4FormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
 
-  TIpv6FormatValidator = class(TBaseFormatValidator)
-  protected
-    function DoValidate(const AValue: string): Boolean; override;
+  TIpv6FormatValidator = class(TRegexFormatValidator)
   public
     constructor Create;
   end;
@@ -141,9 +142,6 @@ type
 procedure RegisterBuiltInFormatValidators;
 
 implementation
-
-uses
-  System.RegularExpressions;
 
 { TBaseFormatValidator }
 
@@ -262,66 +260,48 @@ begin
   end;
 end;
 
+{ TRegexFormatValidator }
+
+constructor TRegexFormatValidator.Create(const AFormatName, APattern: string);
+begin
+  inherited Create(AFormatName);
+  FRegex := TRegEx.Create(APattern, [roCompiled]);
+  if FRegex.IsMatch('') then; // força a compilação lazy fora do hot path // força a compilação lazy aqui, não no hot path
+end;
+
+function TRegexFormatValidator.DoValidate(const AValue: string): Boolean;
+begin
+  Result := FRegex.IsMatch(AValue);
+end;
+
 { TEmailFormatValidator }
 
 constructor TEmailFormatValidator.Create;
 begin
-  inherited Create('email');
-end;
-
-function TEmailFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
-  LRegex := TRegEx.Create('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('email', '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
 end;
 
 { TUriFormatValidator }
 
 constructor TUriFormatValidator.Create;
 begin
-  inherited Create('uri');
-end;
-
-function TUriFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
-  LRegex := TRegEx.Create('^https?://[^\s/$.?#].[^\s]*$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('uri', '^https?://[^\s/$.?#].[^\s]*$');
 end;
 
 { TDateFormatValidator }
 
 constructor TDateFormatValidator.Create;
 begin
-  inherited Create('date');
-end;
-
-function TDateFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
   // Formato YYYY-MM-DD
-  LRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('date', '^\d{4}-\d{2}-\d{2}$');
 end;
 
 { TTimeFormatValidator }
 
 constructor TTimeFormatValidator.Create;
 begin
-  inherited Create('time');
-end;
-
-function TTimeFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
   // Formato HH:MM:SS ou HH:MM:SS.sss
-  LRegex := TRegEx.Create('^\d{2}:\d{2}:\d{2}(\.\d{3})?$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('time', '^\d{2}:\d{2}:\d{2}(\.\d{3})?$');
 end;
 
 { TDateTimeFormatValidator }
@@ -329,17 +309,17 @@ end;
 constructor TDateTimeFormatValidator.Create;
 begin
   inherited Create('date-time');
+  // Formato ISO 8601: YYYY-MM-DDTHH:MM:SS ou YYYY-MM-DDTHH:MM:SSZ
+  FRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?$', [roCompiled]);
+  if FRegex.IsMatch('') then; // força a compilação lazy fora do hot path
 end;
 
 function TDateTimeFormatValidator.DoValidate(const AValue: string): Boolean;
 var
-  LRegex: TRegEx;
   LYear, LMonth, LDay, LHour, LMin, LSec: Integer;
   LDateTimeStr: string;
 begin
-  // Primeiro verifica o formato ISO 8601: YYYY-MM-DDTHH:MM:SS ou YYYY-MM-DDTHH:MM:SSZ
-  LRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?$');
-  if not LRegex.IsMatch(AValue) then
+  if not FRegex.IsMatch(AValue) then
     Exit(False);
   
   // Agora valida se é uma data/hora real válida
@@ -388,45 +368,21 @@ end;
 
 constructor TUuidFormatValidator.Create;
 begin
-  inherited Create('uuid');
-end;
-
-function TUuidFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
-  LRegex := TRegEx.Create('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('uuid', '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
 end;
 
 { TIpv4FormatValidator }
 
 constructor TIpv4FormatValidator.Create;
 begin
-  inherited Create('ipv4');
-end;
-
-function TIpv4FormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
-  LRegex := TRegEx.Create('^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('ipv4', '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$');
 end;
 
 { TIpv6FormatValidator }
 
 constructor TIpv6FormatValidator.Create;
 begin
-  inherited Create('ipv6');
-end;
-
-function TIpv6FormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LRegex: TRegEx;
-begin
-  LRegex := TRegEx.Create('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$');
-  Result := LRegex.IsMatch(AValue);
+  inherited Create('ipv6', '^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$');
 end;
 
 { Registro dos validadores built-in }

--- a/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
+++ b/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
@@ -829,12 +829,9 @@ var
 begin
   LCacheKey := GetCacheKey(ASchema);
 
-  // Verificar cache
-  if FCompiledSchemas.ContainsKey(LCacheKey) then
-  begin
-    Result := FCompiledSchemas[LCacheKey];
+  // Verificar cache (TryGetValue único — antes ContainsKey + indexador)
+  if FCompiledSchemas.TryGetValue(LCacheKey, Result) then
     Exit;
-  end;
 
   // Armazenar o schema raiz para resolu??o de refer?ncias (apenas se n?o estiver definido)
   if not Assigned(FRootSchema) then
@@ -1206,19 +1203,15 @@ begin
 end;
 
 function TSchemaCompiler.GetCacheKey(const ASchema: IJSONElement): string;
-var
-  LSchemaObj: IJSONObject;
-  LIdValue: IJSONValue;
-  LContextKey: string;
 begin
-  LContextKey := _GetCurrentBaseURI;
-  if Supports(ASchema, IJSONObject, LSchemaObj) then
-  begin
-    if LSchemaObj.ContainsKey('$id') and Supports(LSchemaObj.GetValue('$id'), IJSONValue, LIdValue) then
-      LContextKey := LContextKey + '|' + LIdValue.AsString;
-  end;
-  // Gerar hash do schema JSON para usar como chave de cache context-aware
-  Result := IntToStr(THashBobJenkins.GetHashValue(LContextKey + '|' + ASchema.AsJSON));
+  // Chave por IDENTIDADE do nó do schema (ponteiro da interface) + Base URI.
+  // A versão anterior serializava o subschema INTEIRO (AsJSON) e o hasheava a
+  // cada visita de nó do documento — dominava o tempo de validação em
+  // documentos grandes. Os subschemas são nós compartilhados da mesma árvore
+  // (referência estável enquanto o schema estiver carregado), e o cache é
+  // limpo junto com a árvore (ClearCache/ParseSchema), então a identidade é
+  // segura. O $id não precisa entrar na chave: mesmo nó -> mesmo $id.
+  Result := _GetCurrentBaseURI + '|' + IntToHex(NativeUInt(Pointer(ASchema)), SizeOf(Pointer) * 2);
 end;
 
 procedure TSchemaCompiler.ClearCache;
@@ -1531,6 +1524,13 @@ end;
 procedure TJSONSchemaValidator.ParseSchema(const ASchema: IJSONElement);
 begin
   AddLog('ParseSchema called');
+
+  // Schema novo (outra instância) => cache de compilação limpo. Necessário
+  // para a chave por identidade (endereço reutilizado não pode acertar cache
+  // velho) e corrige também o FRootSchema/navigator presos ao schema anterior
+  // quando o validator era reaproveitado.
+  if FSchema <> ASchema then
+    FCompiler.ClearCache;
 
   FSchema := ASchema;
 

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.AdditionalProperties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.AdditionalProperties.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -34,12 +34,15 @@ type
     FAdditionalSchema: IJSONElement;
     FDefinedProperties: TArray<string>;
     FPatternProperties: TArray<string>;
+    FDefinedSet: TDictionary<string, Byte>;
+    FCompiledPatterns: TArray<TRegEx>;
     function IsDefinedProperty(const APropertyName: string): Boolean;
   public
     constructor Create(AAllowAdditional: Boolean;
       const AAdditionalSchema: IJSONElement = nil;
       const ADefinedProperties: TArray<string> = nil;
       const APatternProperties: TArray<string> = nil);
+    destructor Destroy; override;
     function Validate(const AValue: IJSONElement; const AContext: TObject): TValidationResult; override;
   end;
 
@@ -51,34 +54,51 @@ constructor TAdditionalPropertiesRule.Create(AAllowAdditional: Boolean;
   const AAdditionalSchema: IJSONElement;
   const ADefinedProperties: TArray<string>;
   const APatternProperties: TArray<string>);
+var
+  LProp, LPattern: string;
+  LRegex: TRegEx;
 begin
   inherited Create('additionalProperties');
   FAllowAdditional := AAllowAdditional;
   FAdditionalSchema := AAdditionalSchema;
   FDefinedProperties := ADefinedProperties;
   FPatternProperties := APatternProperties;
+
+  // Preparado UMA vez no compile: hash set das propriedades definidas (antes
+  // busca linear por propriedade validada) e regexes pré-compiladas (antes
+  // TRegEx.IsMatch estático compilava a cada chamada).
+  FDefinedSet := TDictionary<string, Byte>.Create;
+  for LProp in ADefinedProperties do
+    FDefinedSet.AddOrSetValue(LProp, 0);
+
+  for LPattern in APatternProperties do
+  begin
+    try
+      LRegex := TRegEx.Create(LPattern, [roCompiled]);
+      if LRegex.IsMatch('') then; // força a compilação lazy fora do hot path
+      FCompiledPatterns := FCompiledPatterns + [LRegex];
+    except
+      // padrão inválido: ignora (comportamento anterior: Exit(False) na 1ª falha)
+    end;
+  end;
+end;
+
+destructor TAdditionalPropertiesRule.Destroy;
+begin
+  FDefinedSet.Free;
+  inherited;
 end;
 
 function TAdditionalPropertiesRule.IsDefinedProperty(const APropertyName: string): Boolean;
 var
-  LDefinedProp: string;
-  LPattern: string;
+  LFor: Integer;
 begin
-  for LDefinedProp in FDefinedProperties do
-  begin
-    if APropertyName = LDefinedProp then
-      Exit(True);
-  end;
+  if FDefinedSet.ContainsKey(APropertyName) then
+    Exit(True);
 
-  for LPattern in FPatternProperties do
-  begin
-    try
-      if TRegEx.IsMatch(APropertyName, LPattern) then
-        Exit(True);
-    except
-      Exit(False);
-    end;
-  end;
+  for LFor := 0 to High(FCompiledPatterns) do
+    if FCompiledPatterns[LFor].IsMatch(APropertyName) then
+      Exit(True);
 
   Result := False;
 end;

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Format.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Format.pas
@@ -96,7 +96,10 @@ begin
     Exit;
   end;
 
-  if not LValue.IsString then
+  // IsDate conta como string: o Reader converte strings ISO-8601 em
+  // TJSONValueDateTime, mas para o JSON Schema o tipo léxico segue sendo
+  // string (AsString devolve a forma ISO para o validador de formato).
+  if not (LValue.IsString or LValue.IsDate) then
   begin
     LError := CreateValidationError(
       LValidationContext.GetFullPath,

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Pattern.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Pattern.pas
@@ -26,6 +26,8 @@ type
   TPatternRule = class(TBaseValidationRule)
   private
     FPattern: string;
+    FRegex: TRegEx;
+    FRegexReady: Boolean;
   public
     constructor Create(const APattern: string);
     function Validate(const AValue: IJSONElement; const AContext: TObject): TValidationResult; override;
@@ -39,6 +41,16 @@ constructor TPatternRule.Create(const APattern: string);
 begin
   inherited Create('pattern');
   FPattern := APattern;
+  // Compila a regex UMA vez — antes era TRegEx.Create por string validada
+  // (compilação PCRE no hot path). Pattern inválido cai no caminho de erro
+  // original dentro do Validate.
+  try
+    FRegex := TRegEx.Create(APattern, [roCompiled]);
+    if FRegex.IsMatch('') then; // força a compilação lazy fora do hot path // força a compilação lazy aqui, não no hot path
+    FRegexReady := True;
+  except
+    FRegexReady := False;
+  end;
 end;
 
 function TPatternRule.Validate(const AValue: IJSONElement; const AContext: TObject): TValidationResult;
@@ -46,7 +58,6 @@ var
   LValue: IJSONValue;
   LError: TValidationError;
   LValidationContext: TValidationContext;
-  LRegex: TRegEx;
 begin
   LValidationContext := TValidationContext(AContext);
   
@@ -79,8 +90,9 @@ begin
   end;
 
   try
-    LRegex := TRegEx.Create(FPattern);
-    if LRegex.IsMatch(LValue.AsString) then
+    if not FRegexReady then
+      raise Exception.CreateFmt('Pattern "%s" failed to compile', [FPattern]);
+    if FRegex.IsMatch(LValue.AsString) then
       Result := TValidationResult.Success(LValidationContext.GetFullPath)
     else
     begin

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.PatternProperties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.PatternProperties.pas
@@ -27,6 +27,7 @@ type
   TPatternPropertiesRule = class(TBaseValidationRule)
   private
     FPatternSchemas: TDictionary<string, IJSONElement>;
+    FCompiledPatterns: TDictionary<string, TRegEx>;
     function ValidatePropertySchema(const AValue: IJSONElement; const ASchema: IJSONElement; const AContext: TValidationContext): TValidationResult;
   public
     constructor Create(const APatternSchemas: TDictionary<string, IJSONElement>);
@@ -42,13 +43,31 @@ uses
 { TPatternPropertiesRule }
 
 constructor TPatternPropertiesRule.Create(const APatternSchemas: TDictionary<string, IJSONElement>);
+var
+  LPattern: string;
+  LRegex: TRegEx;
 begin
   inherited Create('patternProperties');
   FPatternSchemas := APatternSchemas;
+  // Compila cada padrão UMA vez — antes era TRegEx.Create dentro do loop
+  // propriedade × padrão a cada objeto validado. Padrão inválido fica de
+  // fora e é reportado no Validate (mesmo comportamento do try/except antigo).
+  FCompiledPatterns := TDictionary<string, TRegEx>.Create;
+  for LPattern in APatternSchemas.Keys do
+  begin
+    try
+      LRegex := TRegEx.Create(LPattern, [roCompiled]);
+      if LRegex.IsMatch('') then; // força a compilação lazy fora do hot path
+      FCompiledPatterns.Add(LPattern, LRegex);
+    except
+      // padrão inválido: sem entrada no dicionário
+    end;
+  end;
 end;
 
 destructor TPatternPropertiesRule.Destroy;
 begin
+  FCompiledPatterns.Free;
   FPatternSchemas.Free;
   inherited;
 end;
@@ -137,7 +156,10 @@ begin
         for LPattern in FPatternSchemas.Keys do
         begin
           try
-            LRegex := TRegEx.Create(LPattern);
+            // Regex pré-compilada no constructor; padrão inválido não entra
+            // no dicionário e cai no caminho de erro abaixo.
+            if not FCompiledPatterns.TryGetValue(LPattern, LRegex) then
+              raise Exception.CreateFmt('Pattern "%s" failed to compile', [LPattern]);
             if LRegex.IsMatch(LPropertyName) then
             begin
               LPatternSchema := FPatternSchemas[LPattern];

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Types.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Types.pas
@@ -60,6 +60,11 @@ begin
     LValue := AValue as IJSONValue;
     if LValue.IsString then
       LActualType := 'string'
+    else if LValue.IsDate then
+      // O Reader detecta strings ISO-8601 e cria TJSONValueDateTime; para o
+      // JSON Schema o tipo continua sendo "string" (sem isso, qualquer data
+      // num documento reprovava type:string como "unknown").
+      LActualType := 'string'
     else if LValue.IsInteger then
       LActualType := 'integer'
     else if LValue.IsFloat then


### PR DESCRIPTION
## Fase B da auditoria — hot path da validação JSON Schema

Harness: array de 3.000 itens com `properties`/`required`/`pattern`/`format`/`additionalProperties`.

| | Antes | Depois |
|---|---|---|
| Validação completa | ~247ms | **~79ms (3,1×)** |

## Performance

1. **Chave de cache do compilador por identidade do nó** — antes serializava o subschema INTEIRO (`AsJSON`) + hash **a cada nó do documento visitado** (o achado C1, dominante). `ParseSchema` agora limpa o cache ao trocar de schema (de quebra corrige `FRootSchema`/navigator presos ao schema anterior no reuso do validator).
2. **`pattern`**: regex compilada 1× no constructor (antes: compilação PCRE por string validada).
3. **`patternProperties`**: dicionário de regexes pré-compiladas (antes: `TRegEx.Create` dentro do loop propriedade × padrão).
4. **`additionalProperties`**: hash set das propriedades definidas (antes busca linear) + regexes pré-compiladas.
5. **8 format validators built-in** (email/uri/date/time/date-time/uuid/ipv4/ipv6): base `TRegexFormatValidator` com regex compilada 1× por singleton (antes: `TRegEx.Create` por valor).

## Correção (descoberta pelo harness novo)

- Regras `type` e `format` rejeitavam `TJSONValueDateTime` (strings ISO auto-detectadas pelo Reader) — **qualquer data num documento reprovava `type:string` como "unknown"**. `IsDate` agora conta como string em ambas.

## Validação

- ✅ **104/104** testes Schema
- ✅ **15/15** regressões da Fase A (incl. uniqueItems e smoke multi-thread)
- ✅ A/B alternado com exe do baseline na mesma condição de máquina

Pendências registradas para fase futura: contexto heap por nó (M1), `GetFullPath` em sucesso (M2), format validators standalone (`Validators\Format\*.pas`, mesmos padrões — usados só quando registrados explicitamente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)