### PR TITLE
feat: Fase D — contrato de middlewares com validação no registro

### DIFF
--- a/Source/Core/JsonFlow.Builders.pas
+++ b/Source/Core/JsonFlow.Builders.pas
@@ -120,12 +120,12 @@ type
   strict private
     class var FNotifyEventSetValue: TNotifyEventSetValue;
     class var FNotifyEventGetValue: TNotifyEventGetValue;
-    // Snapshot imutável: mutações (AddMiddleware/ClearMiddlewares) trocam o
-    // array inteiro sob lock; leitores iteram a referência local sem lock.
-    // Registre middlewares na inicialização — antes de haver serializações
-    // concorrentes (o TList anterior era iterado e mutado sem sincronização,
-    // corrompendo o enumerador em servidores multi-thread como o Horse).
-    class var FMiddlwareList: TArray<IEventMiddleware>;
+    // Snapshots imutáveis PRÉ-CLASSIFICADOS por contrato: mutações trocam os
+    // arrays sob lock; leitores iteram a referência local sem lock e sem
+    // Supports/QueryInterface por propriedade. Registre middlewares na
+    // inicialização — antes de haver serializações concorrentes.
+    class var FGetMiddlewares: TArray<IGetValueMiddleware>;
+    class var FSetMiddlewares: TArray<ISetValueMiddleware>;
     class var FMiddlwareLock: TObject;
   strict private
     class function _ResolveValueArrayString(const AValue: Variant): TArray<String>; inline;
@@ -298,7 +298,6 @@ var
   LObject: TObject;
   LTypeInfo: PTypeInfo;
   LBreak: Boolean;
-  LMiddleware: IEventMiddleware;
   LGetMw: IGetValueMiddleware;
 
   function L_IsBoolean: Boolean;
@@ -320,12 +319,12 @@ begin
       Exit;
   end;
 
-  // Middlewares GetValue
+  // Middlewares GetValue — lista pré-classificada no registro:
+  // sem Supports/QueryInterface por propriedade.
   LBreak := False;
-  for LMiddleware in FMiddlwareList do
+  for LGetMw in FGetMiddlewares do
   begin
-    if Supports(LMiddleware, IGetValueMiddleware, LGetMw) then
-      LGetMw.GetValue(AInstance, AProperty, Result, LBreak);
+    LGetMw.GetValue(AInstance, AProperty, Result, LBreak);
     if LBreak then
       Exit;
   end;
@@ -435,7 +434,6 @@ var
   LBreak: Boolean;
   LTypeInfo: PTypeInfo;
   LObject: TObject;
-  LMiddleware: IEventMiddleware;
   LSetMw: ISetValueMiddleware;
   LValue: Variant;
   LIntValue: Integer;
@@ -462,12 +460,12 @@ begin
       Exit;
   end;
 
-  // Middlewares SetValue
-  for LMiddleware in FMiddlwareList do
+  // Middlewares SetValue — lista pré-classificada no registro:
+  // sem Supports/QueryInterface por propriedade.
+  for LSetMw in FSetMiddlewares do
   begin
     LBreak := False;
-    if Supports(LMiddleware, ISetValueMiddleware, LSetMw) then
-      LSetMw.SetValue(AInstance, AProperty, LValue, LBreak);
+    LSetMw.SetValue(AInstance, AProperty, LValue, LBreak);
     if LBreak then
       Exit;
   end;
@@ -534,24 +532,52 @@ end;
 
 procedure TJsonBuilder.AddMiddleware(
   const AEventMiddleware: IEventMiddleware);
+var
+  LGetMw: IGetValueMiddleware;
+  LSetMw: ISetValueMiddleware;
+  LHasContract: Boolean;
 begin
+  if not Assigned(AEventMiddleware) then
+    raise EArgumentNilException.Create('Middleware cannot be nil');
+
+  // Contrato validado no REGISTRO: implementar só o marcador IEventMiddleware
+  // seria silenciosamente inútil — falha aqui, não em runtime silencioso.
+  // De quebra o Supports acontece uma única vez, e as listas ficam
+  // pré-classificadas por contrato para os hot paths.
+  LHasContract := False;
   TMonitor.Enter(FMiddlwareLock);
   try
-    FMiddlwareList := FMiddlwareList + [AEventMiddleware];
+    if Supports(AEventMiddleware, IGetValueMiddleware, LGetMw) then
+    begin
+      FGetMiddlewares := FGetMiddlewares + [LGetMw];
+      LHasContract := True;
+    end;
+    if Supports(AEventMiddleware, ISetValueMiddleware, LSetMw) then
+    begin
+      FSetMiddlewares := FSetMiddlewares + [LSetMw];
+      LHasContract := True;
+    end;
   finally
     TMonitor.Exit(FMiddlwareLock);
   end;
+
+  if not LHasContract then
+    raise EArgumentException.Create(
+      'Middleware must implement IGetValueMiddleware and/or ISetValueMiddleware ' +
+      '(implementing only the IEventMiddleware marker has no effect)');
 end;
 
 class constructor TJsonBuilder.Create;
 begin
   FMiddlwareLock := TObject.Create;
-  FMiddlwareList := nil;
+  FGetMiddlewares := nil;
+  FSetMiddlewares := nil;
 end;
 
 class destructor TJsonBuilder.Destroy;
 begin
-  FMiddlwareList := nil;
+  FGetMiddlewares := nil;
+  FSetMiddlewares := nil;
   FMiddlwareLock.Free;
 end;
 
@@ -559,7 +585,8 @@ class procedure TJsonBuilder.ClearMiddlewares;
 begin
   TMonitor.Enter(FMiddlwareLock);
   try
-    FMiddlwareList := nil;
+    FGetMiddlewares := nil;
+    FSetMiddlewares := nil;
   finally
     TMonitor.Exit(FMiddlwareLock);
   end;

--- a/Source/JSON/Core/JsonFlow.Interfaces.pas
+++ b/Source/JSON/Core/JsonFlow.Interfaces.pas
@@ -168,16 +168,35 @@ type
     procedure OnProgress(const AProgress: TProc<TObject, Single>);
   end;
 
+  /// <summary>
+  /// CONTRATO DE MIDDLEWARE — marcador base. Não implemente apenas esta
+  /// interface: todo middleware DEVE implementar IGetValueMiddleware
+  /// (intercepta propriedades na SERIALIZAÇÃO) e/ou ISetValueMiddleware
+  /// (intercepta na DESERIALIZAÇÃO). O registro (TJsonFlow.AddMiddleware /
+  /// TJSONSerializer.AddMiddleware) valida e rejeita implementações sem
+  /// nenhum dos dois contratos. Implementação de referência:
+  /// TMiddlewareDateTime (JsonFlow.MiddlewareDatatime).
+  /// </summary>
   IEventMiddleware = interface
     ['{96402F5C-2C57-45AA-AD31-36900C5EA7DA}']
   end;
 
+  /// <summary>
+  /// Intercepta a leitura de cada propriedade durante a serialização.
+  /// Defina AValue e ABreak := True para substituir o valor serializado
+  /// (o pipeline para no primeiro middleware que der break).
+  /// </summary>
   IGetValueMiddleware = interface(IEventMiddleware)
     ['{C109A7D0-72BA-42F3-9596-F12556746B6E}']
     procedure GetValue(const AInstance: TObject; const AProperty: TRttiProperty;
       var AValue: Variant; var ABreak: Boolean);
   end;
 
+  /// <summary>
+  /// Intercepta a escrita de cada propriedade durante a deserialização.
+  /// Escreva na instância (AProperty.SetValue) e defina ABreak := True para
+  /// assumir a atribuição (o pipeline para no primeiro break).
+  /// </summary>
   ISetValueMiddleware = interface(IEventMiddleware)
     ['{CE2F0793-959A-4747-861E-EC111DDBF01B}']
     procedure SetValue(const AInstance: TObject; const AProperty: TRttiProperty;

--- a/Source/JSON/IO/JsonFlow.Serializer.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.pas
@@ -34,17 +34,6 @@ uses
 
 type
   /// <summary>
-  /// Middleware para customização da serialização
-  /// </summary>
-  TJSONSerializerMiddleware = class abstract
-  public
-    function BeforeSerialize(const APropertyName: string; const AValue: TValue; var AResult: IJSONElement): Boolean; virtual; abstract;
-    function AfterSerialize(const APropertyName: string; const AValue: TValue; var AResult: IJSONElement): Boolean; virtual; abstract;
-    function BeforeDeserialize(const APropertyName: string; const AElement: IJSONElement; var AValue: TValue): Boolean; virtual; abstract;
-    function AfterDeserialize(const APropertyName: string; const AElement: IJSONElement; var AValue: TValue): Boolean; virtual; abstract;
-  end;
-
-  /// <summary>
   /// Opções avançadas de serialização
   /// </summary>
   TJSONSerializerOptions = record
@@ -104,6 +93,14 @@ type
     procedure SerializeToStream(AObject: TObject; AStream: TStream; AStoreClassName: Boolean = False);
   public
     procedure OnLog(const ALogProc: TProc<String>);
+    /// <summary>
+    /// Registro validado: o middleware DEVE implementar IGetValueMiddleware
+    /// e/ou ISetValueMiddleware — implementar só o marcador IEventMiddleware
+    /// seria silenciosamente inútil, então falha aqui, no registro.
+    /// </summary>
+    procedure AddMiddleware(const AMiddleware: IEventMiddleware);
+    // Acesso direto mantido por compatibilidade; prefira AddMiddleware,
+    // que valida o contrato na entrada.
     property Middlewares: TList<IEventMiddleware> read FMiddlewares;
     property Options: TJSONSerializerOptions read FOptions write FOptions;
   end;
@@ -471,23 +468,35 @@ var
   LSetMiddle: ISetValueMiddleware;
   LResult: Variant;
   LBreak: Boolean;
+  LConverted: Boolean;
   LIntValue: Integer;
 begin
   if not Assigned(AInstance) then
     raise EArgumentNilException.Create('Instance cannot be nil');
   if not AProperty.IsWritable then
     Exit;
-  // Middlewares
-  for LFor := 0 to FMiddlewares.Count - 1 do
+  // Middlewares — conversão LAZY: o _JSONToVariant era avaliado por
+  // middleware por propriedade (para objetos/arrays isso serializa a
+  // subárvore inteira via AsJSON); agora converte uma única vez e só quando
+  // o primeiro ISetValueMiddleware é encontrado.
+  if FMiddlewares.Count > 0 then
   begin
-    LMiddle := FMiddlewares[LFor];
-    if Supports(LMiddle, ISetValueMiddleware, LSetMiddle) then
+    LConverted := False;
+    for LFor := 0 to FMiddlewares.Count - 1 do
     begin
-      LBreak := False;
-      LResult := _JSONToVariant(AElement);
-      LSetMiddle.SetValue(AInstance, AProperty, LResult, LBreak);
-      if LBreak then
-        Exit;
+      LMiddle := FMiddlewares[LFor];
+      if Supports(LMiddle, ISetValueMiddleware, LSetMiddle) then
+      begin
+        if not LConverted then
+        begin
+          LResult := _JSONToVariant(AElement);
+          LConverted := True;
+        end;
+        LBreak := False;
+        LSetMiddle.SetValue(AInstance, AProperty, LResult, LBreak);
+        if LBreak then
+          Exit;
+      end;
     end;
   end;
 
@@ -661,6 +670,18 @@ end;
 procedure TJSONSerializer.OnLog(const ALogProc: TProc<String>);
 begin
   FLogProc := ALogProc;
+end;
+
+procedure TJSONSerializer.AddMiddleware(const AMiddleware: IEventMiddleware);
+begin
+  if not Assigned(AMiddleware) then
+    raise EArgumentNilException.Create('Middleware cannot be nil');
+  if not (Supports(AMiddleware, IGetValueMiddleware) or
+          Supports(AMiddleware, ISetValueMiddleware)) then
+    raise EArgumentException.Create(
+      'Middleware must implement IGetValueMiddleware and/or ISetValueMiddleware ' +
+      '(implementing only the IEventMiddleware marker has no effect)');
+  FMiddlewares.Add(AMiddleware);
 end;
 
 function TJSONSerializer.ToObject(const AElement: IJSONElement; AObject: TObject): Boolean;


### PR DESCRIPTION
## Fase D da auditoria — a padronização do contrato de middlewares

**O problema**: o contrato existia (`IGetValueMiddleware`/`ISetValueMiddleware`), mas o registro aceitava o marcador vazio `IEventMiddleware` — dava para registrar um middleware que não implementa nada e ele falhava **em silêncio**.

## Mudanças

1. **Validação no registro** (`TJsonFlow.AddMiddleware` e novo `TJSONSerializer.AddMiddleware`): middleware sem nenhum dos dois contratos → `EArgumentException` na hora, com mensagem explicando. *Fail-fast* em vez de no-op silencioso.
2. **Listas tipadas pré-classificadas** no `TJsonBuilder`: os hot loops por propriedade iteram arrays de `IGetValueMiddleware`/`ISetValueMiddleware` direto — **zero `Supports`/QueryInterface por propriedade** (o Supports acontece 1× no registro).
3. **Conversão lazy no Serializer**: o `_JSONToVariant` era avaliado **por middleware por propriedade** (para objetos/arrays isso serializa a subárvore inteira!); agora converte 1×, só quando o primeiro `ISetValueMiddleware` aparece.
4. **Classe morta removida**: `TJSONSerializerMiddleware` (Before/AfterSerialize que nenhum código chamava) só confundia sobre qual era o contrato real.
5. **Contrato documentado** nas 3 interfaces, com `TMiddlewareDateTime` como implementação de referência.

## Validação

- ✅ Suíte nova da Fase D: **8/8** — rejeição nos 2 pontos de registro, middleware de máscara ponta a ponta (`\"Secret\":\"***\"`), `ClearMiddlewares`, implementação de referência
- ✅ **15/15** Fase A (incl. smoke multi-thread) · **104/104** Schema · harness **byte-idêntico**

🤖 Generated with [Claude Code](https://claude.com/claude-code)