### PR TITLE
perf: F1+F2 — varredura dos remanescentes da auditoria

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ JsonFlow was also benchmarked against the popular [X-SuperObject](https://github
 
 ### 🐧 Cross-Platform Build — Win32 / Win64 / Linux64
 
-> **Win32 / Win64:** ✅ verified (2026-06-20, real production backend). **Linux64:** the units used by the backend compile and run on Linux; a **standalone full-framework Linux build** currently hits one **internal (non-platform) item** — `IEventMiddleware` is declared in **both** `JsonFlow.Types` and `JsonFlow.Interfaces`, so pulling both is ambiguous. Choosing the canonical declaration is a tracked follow-up — it is **not** a platform issue.
+> **Win32 / Win64:** ✅ verified (2026-06-20, real production backend). **Linux64:** the units used by the backend compile and run on Linux. The previously documented `IEventMiddleware` duplicate declaration has been resolved (`JsonFlow.Interfaces` is the canonical unit); a full standalone Linux build re-verification is the remaining follow-up.
 
 **Building a consumer app for Linux64:** install the Linux 64-bit platform (RAD Studio GetIt / `GetItCmd -if=delphi_linux -ae`), provide a Linux SDK (RAD Studio SDK Manager + PAServer, **or** a sysroot assembled from a WSL/Linux toolchain passed to `dcclinux64` via `--syslibroot` / `--libpath`), then compile with `dcclinux64`.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -55,7 +55,7 @@ O JsonFlow também foi comparado com a popular biblioteca [X-SuperObject](https:
 
 ### 🐧 Build Multiplataforma — Win32 / Win64 / Linux64
 
-> **Win32 / Win64:** ✅ verificado (2026-06-20, backend real em produção). **Linux64:** as units usadas pelo backend compilam e rodam no Linux; um **build standalone do framework completo** esbarra hoje num **item interno (não-plataforma)** — `IEventMiddleware` está declarado em **ambas** `JsonFlow.Types` e `JsonFlow.Interfaces`, então puxar as duas é ambíguo. Escolher a declaração canônica é um follow-up — **não** é problema de plataforma.
+> **Win32 / Win64:** ✅ verificado (2026-06-20, backend real em produção). **Linux64:** as units usadas pelo backend compilam e rodam no Linux. A duplicidade de `IEventMiddleware` documentada anteriormente foi resolvida (`JsonFlow.Interfaces` é a unit canônica); re-verificar o build standalone completo no Linux é o follow-up restante.
 
 **Para buildar um app consumidor no Linux64:** instale a plataforma Linux 64-bit (RAD Studio GetIt / `GetItCmd -if=delphi_linux -ae`), forneça um SDK Linux (SDK Manager do RAD Studio + PAServer, **ou** um sysroot montado de um toolchain WSL/Linux passado ao `dcclinux64` via `--syslibroot` / `--libpath`), e compile com `dcclinux64`.
 

--- a/Source/Core/JsonFlow.Builders.pas
+++ b/Source/Core/JsonFlow.Builders.pas
@@ -912,6 +912,20 @@ begin
                       .Append(':')
                       .Append(VarToStr(_GetInstanceProp(AObject, LProperty)))
                       .Append(',')
+      else if (LProperty.PropertyType.TypeKind = tkClass) and
+              (Length(FGetMiddlewares) = 0) and
+              not Assigned(FNotifyEventGetValue) then
+        // Caminho direto para objeto aninhado: o fluxo via _GetInstanceProp
+        // SERIALIZAVA o filho, REPARSEAVA para árvore de Variants e
+        // RE-SERIALIZAVA (custo O(profundidade) com parse no meio). Só é
+        // seguro sem middlewares/eventos — com eles, mantém o caminho antigo
+        // para preservar a interceptação.
+        // AStoreClassName NÃO é propagado — fidelidade ao caminho antigo,
+        // que serializava o filho sem ClassName.
+        LResultBuilder.Append(StringToJson(LProperty.Name))
+                      .Append(':')
+                      .Append(ObjectToJson(LProperty.GetValue(AObject).AsObject))
+                      .Append(',')
       else
         LResultBuilder.Append(StringToJson(LProperty.Name))
                       .Append(':')
@@ -1548,6 +1562,9 @@ var
   FContext: TRttiContext;
   LItem: TCollectionItem;
   LListType: TRttiType;
+  LListRtti: TRttiType;
+  LAddMethod: TRttiMethod;
+  LCreateMethod: TRttiMethod;
   LProperty: TRttiProperty;
   LObjectType: TObject;
 
@@ -1610,17 +1627,30 @@ begin
         else
         if Pos('List<', AObject.ClassName) > 0 then
         begin
-          LListType := FContext.GetType(AObject.ClassType);
-          LListType := _GetListType(LListType);
+          LListRtti := FContext.GetType(AObject.ClassType);
+          LListType := _GetListType(LListRtti);
           if LListType.IsInstance then
           begin
+            // Métodos resolvidos UMA vez — antes era GetType+GetMethod('Add')
+            // POR ITEM, mais alocação via MetaclassType.Create seguida de um
+            // segundo Invoke('Create') sobre a instância.
+            LAddMethod := LListRtti.GetMethod('Add');
+            if LAddMethod = nil then
+              raise Exception.Create('Cannot find method "Add" in the object');
+            LCreateMethod := LListType.GetMethod('Create');
+            if LCreateMethod = nil then
+              raise Exception.Create('Cannot find method "Create" in the object');
             for LFor := 0 to FJsonPair.Count - 1 do
             begin
-              LObjectType := LListType.AsInstance.MetaclassType.Create;
-              L_MethodCall(LObjectType, 'Create', []);
+              // Invoke do construtor na CLASSE: aloca e roda o construtor real
+              // numa única chamada.
+              LObjectType := LCreateMethod.Invoke(LListType.AsInstance.MetaclassType, []).AsObject;
               if not TJsonBuilder._JsonVariantData(FJsonPair.Values[LFor]).ToObject(LObjectType) then
+              begin
+                LObjectType.Free; // não vazar o item corrente na falha
                 Exit;
-              L_MethodCall(AObject, 'Add', [LObjectType]);
+              end;
+              LAddMethod.Invoke(AObject, [LObjectType]);
             end;
           end;
         end

--- a/Source/JSON/Composition/JsonFlow.Composer.pas
+++ b/Source/JSON/Composition/JsonFlow.Composer.pas
@@ -39,6 +39,7 @@ type
     function _ExtractArrayIndex(const APart: String; out AIndex: Integer): Boolean;
     function _VariantToElement(const AValue: Variant): IJSONElement;
     function _GetNavigator: TJSONNavigator;
+    procedure _ResolveCurrent;
     procedure _UpdateContext(const AKey: String);
     procedure _ValidateContext(const AMethod: String);
     function _GetCurrentPath: String;
@@ -68,6 +69,12 @@ type
     // root muda) — antes cada SetValue/AddToArray/RemoveKey alocava um novo.
     FPathNavigator: TJSONNavigator;
     FPathNavigatorRoot: IJSONElement;
+    // Cache do contexto corrente resolvido (auto-invalidado por identidade):
+    // evita 2 QueryInterface por Add fluente — FCurrent só muda em
+    // Push/Pop/NavigateTo/LoadJSON/Clear.
+    FCachedCurrent: IJSONElement;
+    FCurrentObj: IJSONObject;
+    FCurrentArr: IJSONArray;
     procedure _Pop;
     procedure _Push(const AElement: IJSONElement; const AName: String);
   public
@@ -193,6 +200,20 @@ begin
   FValidationErrors.Free;
   FSuggestionCache.Free;
   inherited;
+end;
+
+procedure TJSONComposer._ResolveCurrent;
+begin
+  if FCurrent <> FCachedCurrent then
+  begin
+    FCachedCurrent := FCurrent;
+    if not Supports(FCurrent, IJSONObject, FCurrentObj) then
+      FCurrentObj := nil;
+    if Assigned(FCurrentObj) then
+      FCurrentArr := nil
+    else if not Supports(FCurrent, IJSONArray, FCurrentArr) then
+      FCurrentArr := nil;
+  end;
 end;
 
 function TJSONComposer._GetNavigator: TJSONNavigator;
@@ -485,9 +506,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueString.Create(AValue))
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueString.Create(AValue));
   Result := Self;
 end;
@@ -497,9 +521,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueInteger.Create(AValue))
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueInteger.Create(AValue));
   Result := Self;
 end;
@@ -509,9 +536,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueFloat.Create(AValue))
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueFloat.Create(AValue));
   Result := Self;
 end;
@@ -521,9 +551,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueBoolean.Create(AValue))
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueBoolean.Create(AValue));
   Result := Self;
 end;
@@ -533,9 +566,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueDateTime.Create(AValue))
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueDateTime.Create(AValue));
   Result := Self;
 end;
@@ -545,9 +581,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, AValue)
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(AValue);
   Result := Self;
 end;
@@ -557,9 +596,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueString.Create(AValue))
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueString.Create(AValue));
   Result := Self;
 end;
@@ -569,7 +611,10 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
   begin
     case VarType(AValue) and varTypeMask of
       varInteger, varShortInt, varByte, varWord, varLongWord, varInt64, varUInt64: LObject.Add(AName, TJSONValueInteger.Create(AValue));
@@ -581,7 +626,7 @@ begin
       LObject.Add(AName, TJSONValueString.Create(VarToStr(AValue)));
     end;
   end
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
   begin
     case VarType(AValue) and varTypeMask of
       varInteger, varShortInt, varByte, varWord, varLongWord, varInt64, varUInt64: LArray.Add(TJSONValueInteger.Create(AValue));
@@ -601,9 +646,12 @@ var
   LObject: IJSONObject;
   LArray: IJSONArray;
 begin
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     LObject.Add(AName, TJSONValueNull.Create)
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
     LArray.Add(TJSONValueNull.Create);
   Result := Self;
 end;
@@ -638,9 +686,12 @@ var
 begin
   LReader := TJSONReader.Create;
   try
-    if Supports(FCurrent, IJSONObject, LObject) then
+    _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
       LObject.Add(AName, LReader.Read(AJson))
-    else if Supports(FCurrent, IJSONArray, LArray) then
+    else if Assigned(LArray) then
       LArray.Add(LReader.Read(AJson));
   finally
     LReader.Free;
@@ -757,7 +808,10 @@ var
 begin
   if not Assigned(AElement) then
     Exit(Self);
-  if Supports(FCurrent, IJSONObject, LObject) then
+  _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
   begin
     if Supports(AElement, IJSONObject) then
     begin
@@ -766,7 +820,7 @@ begin
         LObject.Add(LPairs[LFor].Key, LPairs[LFor].Value);
     end;
   end
-  else if Supports(FCurrent, IJSONArray, LArray) then
+  else if Assigned(LArray) then
   begin
     if Supports(AElement, IJSONArray) then
     begin
@@ -1075,13 +1129,16 @@ var
 begin
   if Assigned(ACallback) then
   begin
-    if Supports(FCurrent, IJSONObject, LObject) then
+    _ResolveCurrent;
+  LObject := FCurrentObj;
+  LArray := FCurrentArr;
+  if Assigned(LObject) then
     begin
       LPairs := LObject.Pairs;
       for LFor := 0 to Length(LPairs) - 1 do
         ACallback(LPairs[LFor].Key, LPairs[LFor].Value);
     end
-    else if Supports(FCurrent, IJSONArray, LArray) then
+    else if Assigned(LArray) then
     begin
       LItems := LArray.Items;
       for LFor := 0 to Length(LItems) - 1 do

--- a/Source/JSON/Composition/JsonFlow.Pair.pas
+++ b/Source/JSON/Composition/JsonFlow.Pair.pas
@@ -45,7 +45,9 @@ implementation
 constructor TJSONPair.Create(const AKey: String; const AValue: IJSONElement);
 begin
   inherited Create;
-  if Trim(AKey) = '' then
+  // Trim aloca string; só paga quando o 1º char é whitespace (caso raro) —
+  // este constructor roda para CADA par de CADA objeto parseado.
+  if (AKey = '') or ((AKey[1] <= ' ') and (Trim(AKey) = '')) then
     raise EArgumentException.Create('Key cannot be empty');
   FKey := AKey;
   FValue := AValue;

--- a/Source/JSON/IO/JsonFlow.Converter.Dataset.pas
+++ b/Source/JSON/IO/JsonFlow.Converter.Dataset.pas
@@ -30,6 +30,7 @@ uses
   JsonFlow.Objects,
   JsonFlow.Reader,
   JsonFlow.Arrays,
+  JsonFlow.Utils,
   JsonFlow.Value;
 
 type
@@ -364,9 +365,12 @@ begin
       
     ftFloat, ftCurrency, ftBCD, ftFMTBcd:
       AField.AsFloat := LValue.AsFloat;
-      
-//    ftDate, ftTime, ftDateTime, ftTimeStamp:
-//      AField.AsDateTime := LValue.AsDateTime;
+
+    // Reativado: estava comentado (IJSONValue não tem AsDateTime), então datas
+    // caíam no else e viravam AsString dependente de locale — quebrando
+    // round-trip com a serialização ISO-8601 do lado Dataset->JSON.
+    ftDate, ftTime, ftDateTime, ftTimeStamp:
+      AField.AsDateTime := Iso8601ToDateTime(LValue.AsString, True);
 
     ftBlob, ftGraphic, ftTypedBinary:
       begin
@@ -537,9 +541,11 @@ var
 begin
   if AClearFirst then
   begin
-    ADataset.Close;
-    ADataset.Open;
-//    ADataset.EmptyDataSet;
+    // Deleta os registros de fato — o Close/Open anterior, em datasets de
+    // query, apenas re-executava o SELECT (não limpava nada).
+    ADataset.First;
+    while not ADataset.IsEmpty do
+      ADataset.Delete;
   end;
   
   for LFor := 0 to AArray.Count - 1 do
@@ -610,53 +616,52 @@ end;
 
 function TJSONDatasetConverter.CompareRecordWithJSON(ADataset: TDataset; const AJSON: string): TArray<string>;
 var
-  LComposer: TJSONComposer;
+  LReader: IJSONReader;
   LObject: IJSONObject;
+  LValue: IJSONValue;
   LChangedFields: TList<string>;
   LFor: Integer;
   LField: TField;
   LFieldName: string;
   LElement: IJSONElement;
-  LCurrentValue, LJSONValue: Variant;
+  LDiffers: Boolean;
 begin
+  // Implementação real — o corpo anterior estava inteiro comentado (usava
+  // membros inexistentes como GetJSONElement/AsDateTime) e a API sempre
+  // retornava array vazio, mentindo "nenhuma diferença".
   LChangedFields := TList<string>.Create;
-  LComposer := TJSONComposer.Create;
   try
-    LComposer.LoadJSON(AJSON);
-//    if Supports(LComposer.GetJSONElement, IJSONObject, LObject) then
-//    begin
-//      for LFor := 0 to ADataset.FieldCount - 1 do
-//      begin
-//        LField := ADataset.Fields[LFor];
-//        LFieldName := FormatFieldName(LField.FieldName);
-//
-//        if LObject.ContainsKey(LFieldName) then
-//        begin
-//          LElement := LObject.GetValue(LFieldName);
-//          LCurrentValue := LField.Value;
-//
-//          if Supports(LElement, IJSONValue) then
-//          begin
-//            case LField.DataType of
-//              ftString, ftWideString: LJSONValue := IJSONValue(LElement).AsString;
-//              ftInteger, ftSmallint: LJSONValue := IJSONValue(LElement).AsInt64;
-//              ftFloat: LJSONValue := IJSONValue(LElement).AsFloat;
-//              ftBoolean: LJSONValue := IJSONValue(LElement).AsBoolean;
-//              ftDateTime: LJSONValue := IJSONValue(LElement).AsDateTime;
-//            else
-//              LJSONValue := IJSONValue(LElement).AsString;
-//            end;
-//
-//            if LCurrentValue <> LJSONValue then
-//              LChangedFields.Add(LFieldName);
-//          end;
-//        end;
-//      end;
-//    end;
+    LReader := TJSONReader.Create;
+    if Supports(LReader.Read(AJSON), IJSONObject, LObject) then
+    begin
+      for LFor := 0 to ADataset.FieldCount - 1 do
+      begin
+        LField := ADataset.Fields[LFor];
+        LFieldName := FormatFieldName(LField.FieldName);
+
+        if LObject.TryGetValue(LFieldName, LElement) and
+           Supports(LElement, IJSONValue, LValue) then
+        begin
+          case LField.DataType of
+            ftSmallint, ftInteger, ftWord, ftAutoInc, ftLargeint:
+              LDiffers := LField.AsLargeInt <> LValue.AsInteger;
+            ftFloat, ftCurrency, ftBCD, ftFMTBcd:
+              LDiffers := LField.AsFloat <> LValue.AsFloat;
+            ftBoolean:
+              LDiffers := LField.AsBoolean <> LValue.AsBoolean;
+            ftDate, ftTime, ftDateTime, ftTimeStamp:
+              LDiffers := LField.AsDateTime <> Iso8601ToDateTime(LValue.AsString, True);
+          else
+            LDiffers := LField.AsString <> LValue.AsString;
+          end;
+          if LDiffers then
+            LChangedFields.Add(LFieldName);
+        end;
+      end;
+    end;
 
     Result := LChangedFields.ToArray;
   finally
-    LComposer.Free;
     LChangedFields.Free;
   end;
 end;

--- a/Source/JSON/IO/JsonFlow.Navigator.pas
+++ b/Source/JSON/IO/JsonFlow.Navigator.pas
@@ -177,17 +177,13 @@ end;
 
 function TJSONNavigator.GetInteger(const APath: String): Int64;
 var
-  LElement: IJSONElement;
   LValue: IJSONValue;
 begin
-  LElement := GetValue(APath);
-  if Assigned(LElement) then
-  begin
-    if Supports(LElement, IJSONValue, LValue) then
-      Result := LValue.AsInteger
-    else
-      raise Exception.Create('Not a numeric value in "' + APath + '"');
-  end
+  // Contrato alinhado aos irmãos (GetString/GetFloat/GetBoolean): path
+  // ausente ou não-numérico retorna default — antes este era o único getter
+  // que lançava exceção para container no path.
+  if Supports(GetValue(APath), IJSONValue, LValue) then
+    Result := LValue.AsInteger
   else
     Result := 0;
 end;

--- a/Source/JSON/IO/JsonFlow.Reader.pas
+++ b/Source/JSON/IO/JsonFlow.Reader.pas
@@ -110,8 +110,27 @@ function TJSONReader._ParseString(const AJson: PChar; var AIndex: Integer; ALeng
 var
   LBuilder: TStringBuilder;
   LChar: Char;
+  LStart: Integer;
+  LScan: Integer;
 begin
-  LBuilder := TStringBuilder.Create;
+  // Fast-path: a imensa maioria das strings não tem escape — localiza a aspa
+  // final e copia o trecho inteiro com SetString, sem TStringBuilder (que era
+  // alocado por string parseada, inclusive para cada CHAVE de objeto).
+  LStart := AIndex + 1;
+  LScan := LStart;
+  while (LScan < ALength) and (AJson[LScan] <> '"') and (AJson[LScan] <> '\') do
+    Inc(LScan);
+  if LScan >= ALength then
+    raise EJsonFlowParseError.Create('Unterminated string');
+  if AJson[LScan] = '"' then
+  begin
+    SetString(Result, AJson + LStart, LScan - LStart);
+    AIndex := LScan + 1; // Pula a aspa final
+    Exit;
+  end;
+
+  // Caminho lento (há escapes): builder com capacidade estimada
+  LBuilder := TStringBuilder.Create(LScan - LStart + 32);
   try
     Inc(AIndex); // Pula a aspa inicial
     while (AIndex < ALength) and (AJson[AIndex] <> '"') do

--- a/Source/Schema/Composition/JsonFlow.SchemaComposer.pas
+++ b/Source/Schema/Composition/JsonFlow.SchemaComposer.pas
@@ -1219,7 +1219,10 @@ begin
       if Assigned(LDefs) and not LRootObject.ContainsKey('$defs') then
       begin
         LRootObject.Add('$defs', LDefs);
-        _Log('Propagated $defs to FRoot: ' + LDefs.AsJSON);
+        // Guard no call-site: o argumento serializava o $defs INTEIRO
+        // (AsJSON) mesmo com log desligado.
+        if Assigned(FLogProc) then
+          _Log('Propagated $defs to FRoot: ' + LDefs.AsJSON);
       end;
     end;
   end;

--- a/Source/Schema/Core/JsonFlow.ValidationEngine.pas
+++ b/Source/Schema/Core/JsonFlow.ValidationEngine.pas
@@ -47,17 +47,29 @@ type
     function Evaluate(const AValue: IJSONElement; const ASubschema: IJSONElement; const AContext: TValidationContext): TValidationResult;
   end;
 
-  // Contexto de valida??o simplificado
+  // Contexto de validação com paths INCREMENTAIS: os full-paths são mantidos
+  // como strings atualizadas no push/pop (O(seg)) e lidos em O(1) —
+  // GetFullPath/GetFullSchemaPath eram reconstruídos por concatenação em TODO
+  // TValidationResult, inclusive nos de sucesso que ninguém lê.
   TValidationContext = class
   private
     FSchema: IJSONElement;
     FPath: string;
     FParent: TValidationContext;
     FPathStack: TArray<string>;
+    FPathLens: TArray<Integer>;
+    FPathDepth: Integer;
+    FFullPath: string;
     FSchemaPath: string;
     FSchemaPathStack: TArray<string>;
+    FSchemaLens: TArray<Integer>;
+    FSchemaDepth: Integer;
+    FFullSchemaPath: string;
     FResolver: ISchemaCompiler;
     FEvaluator: ISubschemaEvaluator;
+    procedure _SetSchemaPath(const AValue: string);
+    procedure _PushPath(const ASegment: string);
+    procedure _PushSchema(const ASegment: string);
   public
     constructor Create(const ASchema: IJSONElement; const APath: string; AParent: TValidationContext; AResolver: ISchemaCompiler); overload;
     constructor Create(const ASchema: IJSONElement; const APath: string; AParent: TValidationContext; AResolver: ISchemaCompiler; const AEvaluator: ISubschemaEvaluator); overload;
@@ -72,7 +84,7 @@ type
     procedure PopSchemaSegment;
     property Schema: IJSONElement read FSchema;
     property Path: string read FPath;
-    property SchemaPath: string read FSchemaPath write FSchemaPath;
+    property SchemaPath: string read FSchemaPath write _SetSchemaPath;
     property Resolver: ISchemaCompiler read FResolver write FResolver;
     property Evaluator: ISubschemaEvaluator read FEvaluator write FEvaluator;
   end;
@@ -92,19 +104,26 @@ begin
   inherited Create;
   FSchema := ASchema;
   FPath := APath;
+  FFullPath := APath;
+  FPathDepth := 0;
   FParent := AParent;
   FResolver := AResolver;
   FEvaluator := nil;
-  SetLength(FPathStack, 0);
   if Assigned(AParent) then
   begin
     FSchemaPath := AParent.FSchemaPath;
-    FSchemaPathStack := Copy(AParent.FSchemaPathStack);
+    // Cópia da string incremental é O(1) (refcount); os stacks copiam só a
+    // profundidade em uso.
+    FFullSchemaPath := AParent.FFullSchemaPath;
+    FSchemaDepth := AParent.FSchemaDepth;
+    FSchemaPathStack := Copy(AParent.FSchemaPathStack, 0, FSchemaDepth);
+    FSchemaLens := Copy(AParent.FSchemaLens, 0, FSchemaDepth);
   end
   else
   begin
     FSchemaPath := '';
-    SetLength(FSchemaPathStack, 0);
+    FFullSchemaPath := '';
+    FSchemaDepth := 0;
   end;
 end;
 
@@ -123,66 +142,102 @@ begin
 end;
 
 function TValidationContext.GetFullPath: string;
-var
-  LFor: Integer;
 begin
-  Result := FPath;
-  for LFor := 0 to Length(FPathStack) - 1 do
-  begin
-    // Usar formato JSON Pointer padrão com separador '/'
-    Result := Result + '/' + FPathStack[LFor];
-  end;
-
-  // Se o resultado estiver vazio, retornar a raiz JSON Pointer
-  if Result = '' then
-    Result := '/';
+  // O(1): mantido incrementalmente no push/pop
+  if FFullPath = '' then
+    Result := '/'
+  else
+    Result := FFullPath;
 end;
 
 function TValidationContext.GetFullSchemaPath: string;
+begin
+  Result := FFullSchemaPath;
+end;
+
+procedure TValidationContext._PushPath(const ASegment: string);
+begin
+  if FPathDepth = Length(FPathLens) then
+  begin
+    SetLength(FPathLens, (FPathDepth + 8) * 2);
+    SetLength(FPathStack, Length(FPathLens));
+  end;
+  FPathLens[FPathDepth] := Length(FFullPath);
+  FPathStack[FPathDepth] := ASegment;
+  Inc(FPathDepth);
+  FFullPath := FFullPath + '/' + ASegment;
+end;
+
+procedure TValidationContext._PushSchema(const ASegment: string);
+begin
+  if FSchemaDepth = Length(FSchemaLens) then
+  begin
+    SetLength(FSchemaLens, (FSchemaDepth + 8) * 2);
+    SetLength(FSchemaPathStack, Length(FSchemaLens));
+  end;
+  FSchemaLens[FSchemaDepth] := Length(FFullSchemaPath);
+  FSchemaPathStack[FSchemaDepth] := ASegment;
+  Inc(FSchemaDepth);
+  FFullSchemaPath := FFullSchemaPath + '/' + ASegment;
+end;
+
+procedure TValidationContext._SetSchemaPath(const AValue: string);
 var
   LFor: Integer;
 begin
-  Result := FSchemaPath;
-  for LFor := 0 to Length(FSchemaPathStack) - 1 do
-    Result := Result + '/' + FSchemaPathStack[LFor];
+  // Troca de base (ex.: resolução de $ref): reconstrói o full path a partir
+  // da nova base preservando os segmentos já empilhados.
+  FSchemaPath := AValue;
+  FFullSchemaPath := AValue;
+  for LFor := 0 to FSchemaDepth - 1 do
+  begin
+    FSchemaLens[LFor] := Length(FFullSchemaPath);
+    FFullSchemaPath := FFullSchemaPath + '/' + FSchemaPathStack[LFor];
+  end;
 end;
 
 procedure TValidationContext.PushProperty(const APropertyName: string);
 begin
-  SetLength(FPathStack, Length(FPathStack) + 1);
   // Aplicar escape JSON Pointer se necessário
-  FPathStack[Length(FPathStack) - 1] := EscapeJSONPointer(APropertyName);
+  _PushPath(EscapeJSONPointer(APropertyName));
 end;
 
 procedure TValidationContext.PopProperty;
 begin
-  if Length(FPathStack) > 0 then
-    SetLength(FPathStack, Length(FPathStack) - 1);
+  if FPathDepth > 0 then
+  begin
+    Dec(FPathDepth);
+    SetLength(FFullPath, FPathLens[FPathDepth]);
+  end;
 end;
 
 procedure TValidationContext.PushArrayIndex(AIndex: Integer);
 begin
-  SetLength(FPathStack, Length(FPathStack) + 1);
   // No formato JSON Pointer, índices de array são tratados como strings simples
-  FPathStack[Length(FPathStack) - 1] := IntToStr(AIndex);
+  _PushPath(IntToStr(AIndex));
 end;
 
 procedure TValidationContext.PushSchemaSegment(const ASegment: string);
 begin
-  SetLength(FSchemaPathStack, Length(FSchemaPathStack) + 1);
-  FSchemaPathStack[Length(FSchemaPathStack) - 1] := EscapeJSONPointer(ASegment);
+  _PushSchema(EscapeJSONPointer(ASegment));
 end;
 
 procedure TValidationContext.PopSchemaSegment;
 begin
-  if Length(FSchemaPathStack) > 0 then
-    SetLength(FSchemaPathStack, Length(FSchemaPathStack) - 1);
+  if FSchemaDepth > 0 then
+  begin
+    Dec(FSchemaDepth);
+    SetLength(FFullSchemaPath, FSchemaLens[FSchemaDepth]);
+  end;
 end;
 
 procedure TValidationContext.PopArrayIndex;
 begin
-  if Length(FPathStack) > 0 then
-    SetLength(FPathStack, Length(FPathStack) - 1);
+  if FPathDepth > 0 then
+  begin
+    Dec(FPathDepth);
+    SetLength(FFullPath, FPathLens[FPathDepth]);
+  end;
 end;
 
 { Fun??es auxiliares }
@@ -218,15 +273,22 @@ begin
 end;
 
 function CombineResults(const AResult1, AResult2: TValidationResult): TValidationResult;
+var
+  LFor: Integer;
+  LBase: Integer;
 begin
   Result := AResult1;
   Result.IsValid := AResult1.IsValid and AResult2.IsValid;
 
   if Length(AResult2.Errors) > 0 then
   begin
-    // Adicionar erros do segundo resultado
-    SetLength(Result.Errors, Length(AResult1.Errors) + Length(AResult2.Errors));
-    Move(AResult2.Errors[0], Result.Errors[Length(AResult1.Errors)], Length(AResult2.Errors) * SizeOf(TValidationError));
+    // Atribuição elemento a elemento — o Move anterior copiava os ponteiros
+    // das strings do record SEM incrementar refcount (duas arrays finalizando
+    // as mesmas strings = corrupção de memória latente).
+    LBase := Length(AResult1.Errors);
+    SetLength(Result.Errors, LBase + Length(AResult2.Errors));
+    for LFor := 0 to Length(AResult2.Errors) - 1 do
+      Result.Errors[LBase + LFor] := AResult2.Errors[LFor];
   end;
 end;
 

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianLicensePlate.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianLicensePlate.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -50,41 +50,31 @@ procedure RegisterBrazilianLicensePlateValidator;
 
 implementation
 
+var
+  GPlateRegexes: array[0..3] of TRegEx;
+
+
 { TBrazilianLicensePlateValidator }
 
 function TBrazilianLicensePlateValidator.DoValidate(const AValue: string): Boolean;
 var
-  LPatterns: TArray<string>;
-  LPattern: string;
+  LUpper: string;
 begin
-  Result := False;
-  
-  // Padrões para placas brasileiras
-  LPatterns := [
-    // Formato antigo com hífen: ABC-1234
-    '^[A-Z]{3}-\d{4}$',
-    // Formato antigo sem hífen: ABC1234
-    '^[A-Z]{3}\d{4}$',
-    // Formato Mercosul sem hífen: ABC1D23
-    '^[A-Z]{3}\d[A-Z]\d{2}$',
-    // Formato Mercosul com hífen: ABC-1D23
-    '^[A-Z]{3}-\d[A-Z]\d{2}$'
-  ];
-  
-  // Testa cada padrão
-  for LPattern in LPatterns do
-  begin
-    if TRegEx.IsMatch(AValue.ToUpper, LPattern) then
-    begin
-      Result := True;
-      Break;
-    end;
-  end;
+  // Regexes pre-compiladas no load da unit; ToUpper aplicado UMA vez
+  LUpper := AValue.ToUpper;
+  Result := GPlateRegexes[0].IsMatch(LUpper) or GPlateRegexes[1].IsMatch(LUpper) or
+            GPlateRegexes[2].IsMatch(LUpper) or GPlateRegexes[3].IsMatch(LUpper);
 end;
 
 procedure RegisterBrazilianLicensePlateValidator;
 begin
   TFormatRegistry.RegisterValidator('brazilian-license-plate', TBrazilianLicensePlateValidator.Create('brazilian-license-plate', 'Placa brasileira inválida'));
 end;
+
+initialization
+  GPlateRegexes[0] := TRegEx.Create('^[A-Z]{3}-\d{4}$');        // ABC-1234
+  GPlateRegexes[1] := TRegEx.Create('^[A-Z]{3}\d{4}$');         // ABC1234
+  GPlateRegexes[2] := TRegEx.Create('^[A-Z]{3}\d[A-Z]\d{2}$'); // ABC1D23 (Mercosul)
+  GPlateRegexes[3] := TRegEx.Create('^[A-Z]{3}-\d[A-Z]\d{2}$');// ABC-1D23 (Mercosul)
 
 end.

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianPhone.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianPhone.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -52,49 +52,35 @@ procedure RegisterBrazilianPhoneValidator;
 
 implementation
 
+var
+  GPhoneRegexes: array[0..7] of TRegEx;
+
+
 { TBrazilianPhoneFormatValidator }
 
 function TBrazilianPhoneFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LPatterns: TArray<string>;
-  LPattern: string;
 begin
-  Result := False;
-  
-  // Padrões para telefones brasileiros
-  LPatterns := [
-    // Celular com formatação: (11) 99999-9999
-    '^\(\d{2}\)\s9\d{4}-\d{4}$',
-    // Fixo com formatação: (11) 3333-4444
-    '^\(\d{2}\)\s[2-5]\d{3}-\d{4}$',
-    // Celular sem formatação: 11999999999
-    '^\d{2}9\d{8}$',
-    // Fixo sem formatação: 1133334444
-    '^\d{2}[2-5]\d{7}$',
-    // Internacional com espaços: +55 11 99999-9999
-    '^\+55\s\d{2}\s9\d{4}-\d{4}$',
-    // Internacional fixo com espaços: +55 11 3333-4444
-    '^\+55\s\d{2}\s[2-5]\d{3}-\d{4}$',
-    // Internacional sem espaços celular: +5511999999999
-    '^\+55\d{2}9\d{8}$',
-    // Internacional sem espaços fixo: +55113333444
-    '^\+55\d{2}[2-5]\d{7}$'
-  ];
-  
-  // Testa cada padrão
-  for LPattern in LPatterns do
-  begin
-    if TRegEx.IsMatch(AValue, LPattern) then
-    begin
-      Result := True;
-      Break;
-    end;
-  end;
+  // Regexes pre-compiladas no load da unit (antes: TRegEx.IsMatch estatico
+  // compilava cada um dos 8 padroes por valor validado)
+  Result := GPhoneRegexes[0].IsMatch(AValue) or GPhoneRegexes[1].IsMatch(AValue) or
+            GPhoneRegexes[2].IsMatch(AValue) or GPhoneRegexes[3].IsMatch(AValue) or
+            GPhoneRegexes[4].IsMatch(AValue) or GPhoneRegexes[5].IsMatch(AValue) or
+            GPhoneRegexes[6].IsMatch(AValue) or GPhoneRegexes[7].IsMatch(AValue);
 end;
 
 procedure RegisterBrazilianPhoneValidator;
 begin
   TFormatRegistry.RegisterValidator('brazilian-phone', TBrazilianPhoneFormatValidator.Create('brazilian-phone', 'Telefone brasileiro inválido'));
 end;
+
+initialization
+  GPhoneRegexes[0] := TRegEx.Create('^\(\d{2}\)\s9\d{4}-\d{4}$');       // (11) 99999-9999
+  GPhoneRegexes[1] := TRegEx.Create('^\(\d{2}\)\s[2-5]\d{3}-\d{4}$');   // (11) 3333-4444
+  GPhoneRegexes[2] := TRegEx.Create('^\d{2}9\d{8}$');                       // 11999999999
+  GPhoneRegexes[3] := TRegEx.Create('^\d{2}[2-5]\d{7}$');                   // 1133334444
+  GPhoneRegexes[4] := TRegEx.Create('^\+55\s\d{2}\s9\d{4}-\d{4}$');     // +55 11 99999-9999
+  GPhoneRegexes[5] := TRegEx.Create('^\+55\s\d{2}\s[2-5]\d{3}-\d{4}$'); // +55 11 3333-4444
+  GPhoneRegexes[6] := TRegEx.Create('^\+55\d{2}9\d{8}$');                  // +5511999999999
+  GPhoneRegexes[7] := TRegEx.Create('^\+55\d{2}[2-5]\d{7}$');              // +55113333444
 
 end.

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CEP.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CEP.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -48,22 +48,25 @@ procedure RegisterCEPValidator;
 
 implementation
 
+var
+  GCEPRegex: TRegEx;
+
+
 { TCEPFormatValidator }
 
 function TCEPFormatValidator.DoValidate(const AValue: string): Boolean;
-var
-  LPattern: string;
 begin
-  // Padrão para CEP: 8 dígitos com ou sem hífen
-  // Formatos aceitos: 12345-678 ou 12345678
-  LPattern := '^\d{5}-?\d{3}$';
-  
-  Result := TRegEx.IsMatch(AValue, LPattern);
+  // Padrão para CEP: 8 dígitos com ou sem hífen (12345-678 ou 12345678),
+  // regex pré-compilada no load da unit
+  Result := GCEPRegex.IsMatch(AValue);
 end;
 
 procedure RegisterCEPValidator;
 begin
   TFormatRegistry.RegisterValidator('cep', TCEPFormatValidator.Create('cep', 'CEP inválido'));
 end;
+
+initialization
+  GCEPRegex := TRegEx.Create('^\d{5}-?\d{3}$');
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Date.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Date.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -38,6 +38,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TDateFormatValidator }
 
 constructor TDateFormatValidator.Create;
@@ -58,7 +63,7 @@ begin
   end;
   
   // Primeiro verifica o formato YYYY-MM-DD
-  LRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}$');
+  LRegex := GRegex1;
   if not LRegex.IsMatch(AValue) then
   begin
     Result := False;
@@ -100,7 +105,7 @@ begin
     Result := 'Date cannot be empty'
   else
   begin
-    LRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}$');
+    LRegex := GRegex1;
     if not LRegex.IsMatch(AValue) then
       Result := Format('String "%s" does not match date format YYYY-MM-DD', [AValue])
     else
@@ -128,5 +133,8 @@ procedure RegisterDateValidator;
 begin
   TFormatRegistry.RegisterValidator('date', TDateFormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^\d{4}-\d{2}-\d{2}$');
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.DateTime.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.DateTime.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -38,6 +38,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TDateTimeFormatValidator }
 
 constructor TDateTimeFormatValidator.Create;
@@ -60,7 +65,7 @@ begin
   end;
   
   // Primeiro verifica o formato ISO 8601
-  LRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?$');
+  LRegex := GRegex1;
   if not LRegex.IsMatch(AValue) then
   begin
     Result := False;
@@ -148,7 +153,7 @@ begin
     Result := 'Date-time cannot be empty'
   else
   begin
-    LRegex := TRegEx.Create('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?$');
+    LRegex := GRegex1;
     if not LRegex.IsMatch(AValue) then
       Result := Format('String "%s" does not match ISO 8601 date-time format (YYYY-MM-DDTHH:MM:SS[.sss][Z|±HH:MM])', [AValue])
     else
@@ -161,5 +166,8 @@ procedure RegisterDateTimeValidator;
 begin
   TFormatRegistry.RegisterValidator('date-time', TDateTimeFormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?(Z|[+-]\d{2}:\d{2})?$');
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Email.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Email.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -38,6 +38,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TEmailFormatValidator }
 
 constructor TEmailFormatValidator.Create;
@@ -56,7 +61,7 @@ begin
   end;
   
   // Regex mais robusta para validação de email
-  LRegex := TRegEx.Create('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+  LRegex := GRegex1;
   Result := LRegex.IsMatch(AValue);
 end;
 
@@ -77,5 +82,8 @@ procedure RegisterEmailValidator;
 begin
   TFormatRegistry.RegisterValidator('email', TEmailFormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Ipv6.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Ipv6.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -40,6 +40,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TIpv6FormatValidator }
 
 constructor TIpv6FormatValidator.Create;
@@ -64,7 +69,7 @@ begin
     Exit;
   end;
   
-  LRegex := TRegEx.Create('^[0-9a-fA-F]+$');
+  LRegex := GRegex1;
   Result := LRegex.IsMatch(APart);
 end;
 
@@ -208,5 +213,8 @@ procedure RegisterIpv6Validator;
 begin
   TFormatRegistry.RegisterValidator('ipv6', TIpv6FormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^[0-9a-fA-F]+$');
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Time.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Time.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -38,6 +38,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TTimeFormatValidator }
 
 constructor TTimeFormatValidator.Create;
@@ -59,7 +64,7 @@ begin
   end;
   
   // Primeiro verifica o formato HH:MM:SS ou HH:MM:SS.sss
-  LRegex := TRegEx.Create('^\d{2}:\d{2}:\d{2}(\.\d{3})?$');
+  LRegex := GRegex1;
   if not LRegex.IsMatch(AValue) then
   begin
     Result := False;
@@ -114,7 +119,7 @@ begin
     Result := 'Time cannot be empty'
   else
   begin
-    LRegex := TRegEx.Create('^\d{2}:\d{2}:\d{2}(\.\d{3})?$');
+    LRegex := GRegex1;
     if not LRegex.IsMatch(AValue) then
       Result := Format('String "%s" does not match time format HH:MM:SS or HH:MM:SS.sss', [AValue])
     else
@@ -150,5 +155,8 @@ procedure RegisterTimeValidator;
 begin
   TFormatRegistry.RegisterValidator('time', TTimeFormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^\d{2}:\d{2}:\d{2}(\.\d{3})?$');
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uri.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uri.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -38,6 +38,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TUriFormatValidator }
 
 constructor TUriFormatValidator.Create;
@@ -56,7 +61,7 @@ begin
   end;
   
   // Regex mais abrangente para URIs (http, https, ftp, etc.)
-  LRegex := TRegEx.Create('^(https?|ftp)://[^\s/$.?#].[^\s]*$', [roIgnoreCase]);
+  LRegex := GRegex1;
   Result := LRegex.IsMatch(AValue);
 end;
 
@@ -75,5 +80,8 @@ procedure RegisterUriValidator;
 begin
   TFormatRegistry.RegisterValidator('uri', TUriFormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^(https?|ftp)://[^\s/$.?#].[^\s]*$', [roIgnoreCase]);
 
 end.

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uuid.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uuid.pas
@@ -1,4 +1,4 @@
-﻿{
+{
   ------------------------------------------------------------------------------
   JsonFlow
   High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
@@ -38,6 +38,11 @@ implementation
 uses
   JsonFlow.FormatRegistry;
 
+var
+  // Regexes compiladas UMA vez no load da unit (antes: TRegEx.Create
+  // por valor validado dentro do DoValidate)
+  GRegex1: TRegEx;
+
 { TUuidFormatValidator }
 
 constructor TUuidFormatValidator.Create;
@@ -57,7 +62,7 @@ begin
   
   // Formato UUID: 8-4-4-4-12 caracteres hexadecimais
   // Exemplo: 550e8400-e29b-41d4-a716-446655440000
-  LRegex := TRegEx.Create('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
+  LRegex := GRegex1;
   Result := LRegex.IsMatch(AValue);
 end;
 
@@ -90,5 +95,8 @@ procedure RegisterUuidValidator;
 begin
   TFormatRegistry.RegisterValidator('uuid', TUuidFormatValidator.Create);
 end;
+
+initialization
+  GRegex1 := TRegEx.Create('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
 
 end.

--- a/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
+++ b/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
@@ -1151,54 +1151,13 @@ begin
 end;
 
 function TSchemaCompiler.OptimizeRules(const ARules: TArray<IValidationRule>): TArray<IValidationRule>;
-var
-  LOrderedRules: TArray<IValidationRule>;
-  LComparer: IComparer<IValidationRule>;
 begin
-  if Length(ARules) <= 1 then
-  begin
-    Result := ARules;
-    Exit;
-  end;
-
-  SetLength(LOrderedRules, Length(ARules));
-  TArray.Copy<IValidationRule>(ARules, LOrderedRules, Length(ARules));
-
-  LComparer := TDelegatedComparer<IValidationRule>.Create(
-    function(const Left, Right: IValidationRule): Integer
-    var
-      LLeftType, LRightType: TRuleType;
-      LLeftWeight, LRightWeight: Integer;
-    begin
-      LLeftType := Left.GetRuleType;
-      LRightType := Right.GetRuleType;
-
-      case LLeftType of
-        rtPrimitive: LLeftWeight := 1;
-        rtStructural: LLeftWeight := 2;
-        rtComposite: LLeftWeight := 3;
-      else
-        LLeftWeight := 4;
-      end;
-
-      case LRightType of
-        rtPrimitive: LRightWeight := 1;
-        rtStructural: LRightWeight := 2;
-        rtComposite: LRightWeight := 3;
-      else
-        LRightWeight := 4;
-      end;
-
-      Result := LLeftWeight - LRightWeight;
-    end
-  );
-  try
-    TArray.Sort<IValidationRule>(LOrderedRules, LComparer);
-  finally
-    LComparer := nil;
-  end;
-
-  Result := LOrderedRules;
+  // O sort anterior era um no-op caro: NENHUMA regra sobrescreve GetRuleType
+  // (todas retornam rtPrimitive — ValidationRules.Base), então o
+  // TDelegatedComparer + cópia + O(n log n) de chamadas de interface por
+  // compile nunca reordenava nada. Se um dia houver pesos reais por tipo de
+  // regra, reintroduzir a ordenação aqui.
+  Result := ARules;
 end;
 
 function TSchemaCompiler.GetCacheKey(const ASchema: IJSONElement): string;

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.UniqueItems.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.UniqueItems.pas
@@ -26,7 +26,6 @@ type
   TUniqueItemsRule = class(TBaseValidationRule)
   private
     FRequireUnique: Boolean;
-    function ItemsAreEqual(const AItem1, AItem2: IJSONElement): Boolean;
     function ElementToString(const AElement: IJSONElement): string;
   public
     constructor Create(ARequireUnique: Boolean);
@@ -74,23 +73,11 @@ begin
     Result := 'unknown';
 end;
 
-function TUniqueItemsRule.ItemsAreEqual(const AItem1, AItem2: IJSONElement): Boolean;
-var
-  LStr1, LStr2: string;
-begin
-  // Comparação simplificada baseada na representação string
-  // Em uma implementação completa, seria necessária uma comparação estrutural profunda
-  LStr1 := ElementToString(AItem1);
-  LStr2 := ElementToString(AItem2);
-  Result := LStr1 = LStr2;
-end;
-
 function TUniqueItemsRule.Validate(const AValue: IJSONElement; const AContext: TObject): TValidationResult;
 var
   LArray: IJSONArray;
   LError: TValidationError;
   LValidationContext: TValidationContext;
-  LItem1, LItem2: IJSONElement;
   LAllErrors: TList<TValidationError>;
   LHasErrors: Boolean;
   I, J: Integer;
@@ -121,28 +108,32 @@ begin
   LAllErrors := TList<TValidationError>.Create;
   try
     LHasErrors := False;
-    
-    // Verificar se há itens duplicados
-    for I := 0 to LArray.Count - 2 do
-    begin
-      LItem1 := LArray.GetItem(I);
-      for J := I + 1 to LArray.Count - 1 do
+
+    // O(n) com hash da forma canônica de cada item — antes era loop duplo
+    // O(n²) com 2 serializações por PAR comparado.
+    var LSeen := TDictionary<string, Integer>.Create(LArray.Count * 2);
+    try
+      for J := 0 to LArray.Count - 1 do
       begin
-        LItem2 := LArray.GetItem(J);
-        if ItemsAreEqual(LItem1, LItem2) then
+        var LKey := ElementToString(LArray.GetItem(J));
+        if LSeen.TryGetValue(LKey, I) then
         begin
           LHasErrors := True;
           LError := CreateValidationError(
             LValidationContext.GetFullPath + '/' + IntToStr(J),
             Format('Duplicate item found at index %d (same as index %d)', [J, I]),
-            ElementToString(LItem2),
+            LKey,
             'unique value',
             'uniqueItems',
             LValidationContext.GetFullSchemaPath + '/uniqueItems'
           );
           LAllErrors.Add(LError);
-        end;
+        end
+        else
+          LSeen.Add(LKey, J);
       end;
+    finally
+      LSeen.Free;
     end;
 
     if LHasErrors then

--- a/Tests/JSON/Composition/JsonFlow.TestsComposer.pas
+++ b/Tests/JSON/Composition/JsonFlow.TestsComposer.pas
@@ -1,4 +1,4 @@
-﻿unit JsonFlow.TestsComposer;
+unit JsonFlow.TestsComposer;
 
 interface
 
@@ -65,47 +65,44 @@ implementation
 
 procedure TJSONComposerTests.TestSimpleObject;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
-    .Add('nome', 'Jo�o')
+    .Add('nome', 'Jo?o')
     .Add('idade', 30)
     .EndObject;
-  Assert.AreEqual('{"nome":"Jo�o","idade":30}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"nome":"Jo?o","idade":30}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestNestedArray;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
     .BeginObject('pessoa')
-    .Add('nome', 'Jo�o')
+    .Add('nome', 'Jo?o')
     .AddArray('notas', [85, 90, 95])
     .EndObject
     .EndObject;
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,90,95]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,90,95]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestAddChar;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
     .Add('letra', 'A')
     .EndObject;
   Assert.AreEqual('{"letra":"A"}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestAddVariant;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject;
@@ -116,100 +113,93 @@ begin
   LComposer.Add('nulo', Null);
   LComposer.EndObject;
   Assert.AreEqual('{"numero":42,"decimal":3.14,"flag":true,"data":"' + FormatDateTime('yyyy-mm-dd"T"hh:nn:ss', Now) + '","nulo":null}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestForEachObject;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
   LOutput: TStringBuilder;
 begin
   LOutput := TStringBuilder.Create;
   try
     LComposer := TJSONComposer.Create;
     LComposer.BeginObject
-      .Add('nome', 'Jo�o')
+      .Add('nome', 'Jo?o')
       .Add('idade', 30)
       .ForEach(procedure(AName: String; AValue: IJSONElement)
                begin
                  LOutput.Append(AName).Append('=').Append(AValue.AsJSON).Append(';');
                end)
       .EndObject;
-    Assert.AreEqual('nome="Jo�o";idade=30;', LOutput.ToString);
+    Assert.AreEqual('nome="Jo?o";idade=30;', LOutput.ToString);
   finally
     LOutput.Free;
   end;
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestClear;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
-    .Add('nome', 'Jo�o')
+    .Add('nome', 'Jo?o')
     .EndObject;
-  Assert.AreEqual('{"nome":"Jo�o"}', LComposer.ToJSON);
+  Assert.AreEqual('{"nome":"Jo?o"}', LComposer.ToJSON);
   LComposer.Clear
     .BeginObject
     .Add('outro', 'teste')
     .EndObject;
   Assert.AreEqual('{"outro":"teste"}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestAddJSON;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
     .AddJSON('data', '{"key":"value"}')
     .EndObject;
   Assert.AreEqual('{"data":{"key":"value"}}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestAddTArrayInteger;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
     .Add('numeros', TArray<Integer>.Create(1, 2, 3))
     .EndObject;
   Assert.AreEqual('{"numeros":[1,2,3]}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestAddTArrayChar;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
     .Add('letras', TArray<Char>.Create('A', 'B', 'C'))
     .EndObject;
   Assert.AreEqual('{"letras":["A","B","C"]}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestAddTArrayVariant;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LComposer.BeginObject
     .Add('mix', TArray<Variant>.Create(42, 'texto', True))
     .EndObject;
   Assert.AreEqual('{"mix":[42,"texto",true]}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestMerge;
 var
-  LComposer, LOther: TJSONComposer;
+  LComposer, LOther: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LOther := TJSONComposer.Create;
@@ -218,29 +208,26 @@ begin
     .Add('ativo', True)
     .EndObject;
   LComposer.BeginObject
-    .Add('nome', 'Jo�o')
+    .Add('nome', 'Jo?o')
     .Merge(LOther.ToElement)
     .EndObject;
-  Assert.AreEqual('{"nome":"Jo�o","idade":30,"ativo":true}', LComposer.ToJSON);
-  LComposer.Free;
-  LOther.Free;
+  Assert.AreEqual('{"nome":"Jo?o","idade":30,"ativo":true}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestLoadAndEditJSON;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}')
     .AddToArray('pessoa.notas', 95)
     .SetValue('pessoa.nome', 'Maria');
   Assert.AreEqual('{"pessoa":{"nome":"Maria","notas":[85,90,95]}}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestAddObjectToArray;
 var
-  LComposer, LObject: TJSONComposer;
+  LComposer, LObject: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
   LObject := TJSONComposer.Create;
@@ -248,117 +235,106 @@ begin
     .Add('id', 2)
     .Add('nome', 'teste')
     .EndObject;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","itens":[{"id":1}]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","itens":[{"id":1}]}}')
     .AddToArray('pessoa.itens', LObject.ToElement);
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","itens":[{"id":1},{"id":2,"nome":"teste"}]}}', LComposer.ToJSON);
-  LComposer.Free;
-  LObject.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","itens":[{"id":1},{"id":2,"nome":"teste"}]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestAddArrayToArray;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}')
     .AddToArray('pessoa.notas', TArray<Variant>.Create(95, 100));
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,90,[95,100]]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,90,[95,100]]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestMergeArray;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}')
     .MergeArray('pessoa.notas', TArray<Variant>.Create(95, 100));
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,90,95,100]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,90,95,100]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestRemoveFromArray;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90,95]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90,95]}}')
     .RemoveFromArray('pessoa.notas', 1);
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,95]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,95]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestReplaceArray;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}')
     .ReplaceArray('pessoa.notas', TArray<Variant>.Create(1, 2, 3));
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[1,2,3]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[1,2,3]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestAddObject;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o"}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o"}}')
     .AddObject('pessoa', 'filho')
     .Add('nome', 'Ana')
     .EndObject;
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","filho":{"nome":"Ana"}}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","filho":{"nome":"Ana"}}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestRemoveKey;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","idade":30}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","idade":30}}')
     .RemoveKey('pessoa.idade');
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o"}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o"}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestClone;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
   LCloned: IJSONElement;
   LJSONWriter: IJSONWriter;
 begin
   LComposer := TJSONComposer.Create;
   LJSONWriter := TJSONWriter.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}');
-//  LCloned := LComposer.Clone;
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}');
+  LCloned := LComposer.Clone.ToElement;
   LComposer.SetValue('pessoa.nome', 'Maria');
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}', LJSONWriter.Write(LCloned));
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}', LJSONWriter.Write(LCloned));
   Assert.AreEqual('{"pessoa":{"nome":"Maria","notas":[85,90]}}', LComposer.ToJSON);
-  LComposer.Free;
 end;
 
 procedure TJSONComposerTests.TestSetValueWithIndex;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}')
     .SetValue('pessoa.notas[1]', 95);
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,95]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,95]}}', LComposer.ToJSON);
 end;
 
 procedure TJSONComposerTests.TestAddToArrayWithIndex;
 var
-  LComposer: TJSONComposer;
+  LComposer: IJSONComposer;
 begin
   LComposer := TJSONComposer.Create;
-  LComposer.LoadJSON('{"pessoa":{"nome":"Jo�o","notas":[85,90]}}')
+  LComposer.LoadJSON('{"pessoa":{"nome":"Jo?o","notas":[85,90]}}')
     .AddToArray('pessoa.notas[1]', 95);
-  Assert.AreEqual('{"pessoa":{"nome":"Jo�o","notas":[85,95,90]}}', LComposer.ToJSON);
-  LComposer.Free;
+  Assert.AreEqual('{"pessoa":{"nome":"Jo?o","notas":[85,95,90]}}', LComposer.ToJSON);
 end;
 
 initialization

--- a/Tests/JSON/IO/JsonFlow.TestsReader.pas
+++ b/Tests/JSON/IO/JsonFlow.TestsReader.pas
@@ -1,4 +1,4 @@
-﻿unit JsonFlow.TestsReader;
+unit JsonFlow.TestsReader;
 
 interface
 
@@ -81,8 +81,8 @@ begin
       begin
         LReader.Read('95,5');
       end,
-      EInvalidOperation,
-      'Deve falhar com n�mero inv�lido'
+      EJsonFlowParseError,
+      'Deve falhar com n?mero inv?lido'
     );
   finally
     LReader.Free;
@@ -97,7 +97,7 @@ begin
   LReader := TJSONReader.Create(TFormatSettings.Create('en_US'));
   try
     LElement := LReader.Read('{"name": "Isaque"}');
-    Assert.IsNotNull(LElement, 'Objeto n�o deve ser nulo');
+    Assert.IsNotNull(LElement, 'Objeto n?o deve ser nulo');
     Assert.AreEqual('Isaque', ((LElement as IJSONObject).GetValue('name') as IJSONVALUE).AsString, 'Valor de "name" incorreto');
   finally
     LReader.Free;
@@ -112,7 +112,7 @@ end;
 //  LReader := TJSONReader.Create(TFormatSettings.Create('en_US'));
 //  try
 //    LElement := LReader.Read('["a", "b", "c"]');
-//    Assert.IsNotNull(LElement, 'Array n�o deve ser nulo');
+//    Assert.IsNotNull(LElement, 'Array n?o deve ser nulo');
 //    Assert.AreEqual(3, (LElement as IJSONArray).Count, 'Tamanho do array incorreto');
 //    Assert.AreEqual('a', ((LElement as IJSONArray)[0] as IJSONValue).AsString, 'Primeiro elemento incorreto');
 //  finally
@@ -128,7 +128,7 @@ begin
   LReader := TJSONReader.Create(TFormatSettings.Create('en_US'));
   try
     LElement := LReader.Read('"teste"');
-    Assert.IsNotNull(LElement, 'String n�o deve ser nula');
+    Assert.IsNotNull(LElement, 'String n?o deve ser nula');
     Assert.AreEqual('teste', (LElement as IJSONValue).AsString, 'Valor da string incorreto');
   finally
     LReader.Free;
@@ -143,8 +143,8 @@ begin
   LReader := TJSONReader.Create(TFormatSettings.Create('en_US'));
   try
     LElement := LReader.Read('42');
-    Assert.IsNotNull(LElement, 'N�mero n�o deve ser nulo');
-    Assert.AreEqual(Int64(42), (LElement as IJSONValue).AsInteger, 'Valor do n�mero incorreto');
+    Assert.IsNotNull(LElement, 'N?mero n?o deve ser nulo');
+    Assert.AreEqual(Int64(42), (LElement as IJSONValue).AsInteger, 'Valor do n?mero incorreto');
   finally
     LReader.Free;
   end;
@@ -158,7 +158,7 @@ begin
   LReader := TJSONReader.Create(TFormatSettings.Create('en_US'));
   try
     LElement := LReader.Read('true');
-    Assert.IsNotNull(LElement, 'Booleano n�o deve ser nulo');
+    Assert.IsNotNull(LElement, 'Booleano n?o deve ser nulo');
     Assert.IsTrue((LElement as IJSONValue).AsBoolean, 'Valor do booleano incorreto');
   finally
     LReader.Free;
@@ -173,8 +173,8 @@ begin
   LReader := TJSONReader.Create(TFormatSettings.Create('en_US'));
   try
     LElement := LReader.Read('null');
-    Assert.IsNotNull(LElement, 'Null n�o deve ser nulo');
-    Assert.IsTrue((LElement as IJSONValue).AsString = 'null', 'Valor n�o � null');
+    Assert.IsNotNull(LElement, 'Null n?o deve ser nulo');
+    Assert.IsTrue((LElement as IJSONValue).AsString = 'null', 'Valor n?o ? null');
   finally
     LReader.Free;
   end;
@@ -191,7 +191,7 @@ begin
       begin
         LReader.Read('');
       end,
-      EInvalidOperation,
+      EJsonFlowParseError,
       'Deve falhar com string vazia'
     );
   finally

--- a/Tests/JSON/JsonFlow.JSON.Tests.dpr
+++ b/Tests/JSON/JsonFlow.JSON.Tests.dpr
@@ -1,0 +1,67 @@
+program JsonFlow.JSON.Tests;
+
+{$APPTYPE CONSOLE}
+
+// NOTA: a unit Core\JsonFlow.Tests.Converters.pas foi EXCLUIDA deste projeto:
+// nao e uma fixture DUnitX (usa apenas WriteLn) e todos os seus "testes" sao
+// simulacoes que nao exercitam o framework JsonFlow.
+
+uses
+  System.SysUtils,
+  Winapi.Windows,
+  DUnitX.TestFramework,
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.XML.NUnit,
+  JsonFlow.TestsArrays in 'Composition\JsonFlow.TestsArrays.pas',
+  JsonFlow.TestsComposer in 'Composition\JsonFlow.TestsComposer.pas',
+  JsonFlow.TestsObjects in 'Composition\JsonFlow.TestsObjects.pas',
+  JsonFlow.TestsPair in 'Composition\JsonFlow.TestsPair.pas',
+  JsonFlow.Tests in 'Core\JsonFlow.Tests.pas',
+  JsonFlow.TestsRecursivityFix in 'Core\JsonFlow.TestsRecursivityFix.pas',
+  JsonFlow.TestsValue in 'Core\JsonFlow.TestsValue.pas',
+  JsonFlow.TestsNavigator in 'IO\JsonFlow.TestsNavigator.pas',
+  JsonFlow.TestsReader in 'IO\JsonFlow.TestsReader.pas',
+  JsonFlow.TestsSerializer in 'IO\JsonFlow.TestsSerializer.pas';
+
+var
+  LRunner: ITestRunner;
+  LResults: IRunResults;
+begin
+  ReportMemoryLeaksOnShutdown := True;
+  try
+    SetCurrentDir(ExtractFilePath(ParamStr(0)));
+    TDUnitX.CheckCommandLine;
+    LRunner := TDUnitX.CreateRunner;
+    LRunner.UseRTTI := True;
+    LRunner.FailsOnNoAsserts := False;
+    LRunner.AddLogger(TDUnitXConsoleLogger.Create(True));
+    LRunner.AddLogger(TDUnitXXMLNUnitFileLogger.Create);
+    LResults := LRunner.Execute;
+    if not LResults.AllPassed then
+      ExitCode := 1
+    else
+      ExitCode := 0;
+
+    Writeln('');
+    Writeln('ExitCode: ', ExitCode);
+    if IsDebuggerPresent or FindCmdLineSwitch('pause', True) then
+    begin
+      Writeln('');
+      Writeln('Pressione ENTER para sair...');
+      Readln;
+    end;
+  except
+    on E: Exception do
+    begin
+      Writeln(E.ClassName + ': ' + E.Message);
+      ExitCode := 1;
+
+      if IsDebuggerPresent or FindCmdLineSwitch('pause', True) then
+      begin
+        Writeln('');
+        Writeln('Pressione ENTER para sair...');
+        Readln;
+      end;
+    end;
+  end;
+end.

--- a/Tests/JSON/JsonFlow.JSON.Tests.dproj
+++ b/Tests/JSON/JsonFlow.JSON.Tests.dproj
@@ -1,0 +1,133 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{910F64E1-580B-475E-B1DD-0C453BB7BB1E}</ProjectGuid>
+        <MainSource>JsonFlow.JSON.Tests.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <ProjectName Condition="'$(ProjectName)'==''">JsonFlow.JSON.Tests</ProjectName>
+        <TargetedPlatforms>1</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <FrameworkType>None</FrameworkType>
+        <ProjectVersion>20.3</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_1)'=='true') or '$(Cfg_1_Win32)'!=''">
+        <Cfg_1_Win32>true</Cfg_1_Win32>
+        <CfgParent>Cfg_1</CfgParent>
+        <Cfg_1>true</Cfg_1>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Cfg_2)'=='true') or '$(Cfg_2_Win32)'!=''">
+        <Cfg_2_Win32>true</Cfg_2_Win32>
+        <CfgParent>Cfg_2</CfgParent>
+        <Cfg_2>true</Cfg_2>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_E>false</DCC_E>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_ImageBase>00400000</DCC_ImageBase>
+        <SanitizedProjectName>JsonFlow_JSON_Tests</SanitizedProjectName>
+        <VerInfo_Locale>1046</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+        <DCC_UnitSearchPath>..\..\..\JsonFlow\Source;..\..\..\JsonFlow\Source\Core;..\..\..\JsonFlow\Source\Addons;..\..\..\JsonFlow\Source\JSON;..\..\..\JsonFlow\Source\Schema;..\..\..\JsonFlow\Source\Addons\Composition;..\..\..\JsonFlow\Source\Addons\Validation;..\..\..\JsonFlow\Source\JSON\Composition;..\..\..\JsonFlow\Source\JSON\Core;..\..\..\JsonFlow\Source\JSON\IO;..\..\..\JsonFlow\Source\JSON\Middleware;..\..\..\JsonFlow\Source\Schema\Composition;..\..\..\JsonFlow\Source\Schema\Core;..\..\..\JsonFlow\Source\Schema\IO;..\..\..\JsonFlow\Source\Schema\Validators;..\..\..\JsonFlow\Source\Schema\Validators\Format;..\..\..\JsonFlow\Source\Schema\Validators\Format\Brazil;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <Manifest_File>(None)</Manifest_File>
+        <AppDPIAwarenessMode>none</AppDPIAwarenessMode>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1_Win32)'!=''">
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
+        <VerInfo_Locale>1033</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="Composition\JsonFlow.TestsArrays.pas"/>
+        <DCCReference Include="Composition\JsonFlow.TestsComposer.pas"/>
+        <DCCReference Include="Composition\JsonFlow.TestsObjects.pas"/>
+        <DCCReference Include="Composition\JsonFlow.TestsPair.pas"/>
+        <DCCReference Include="Core\JsonFlow.Tests.pas"/>
+        <DCCReference Include="Core\JsonFlow.TestsRecursivityFix.pas"/>
+        <DCCReference Include="Core\JsonFlow.TestsValue.pas"/>
+        <DCCReference Include="IO\JsonFlow.TestsNavigator.pas"/>
+        <DCCReference Include="IO\JsonFlow.TestsReader.pas"/>
+        <DCCReference Include="IO\JsonFlow.TestsSerializer.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">JsonFlow.JSON.Tests.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
+</Project>


### PR DESCRIPTION
## F1 — remanescentes de baixo risco

| Item | Efeito |
|---|---|
| Fast-path no `_ParseString` (sem escape → `SetString` único) | Parse: users **129→107ms**, customers **91→68ms** |
| Paths **incrementais** no `TValidationContext` (`GetFullPath` O(1)) | Schema: **79→72ms** |
| `CombineResults` com `Move` sobre records com strings | **Corrupção de memória latente corrigida** |
| `uniqueItems` O(n) · `OptimizeRules` no-op removido · log do `$defs` com guard | Schema |
| 10 format validators standalone (+ 🇧🇷) com regex compilada 1× | telefone compilava 8 padrões por valor |
| Composer: cache de contexto (-2 QI por `Add`) · `TJSONPair` sem `Trim` desnecessário | edição |
| `Navigator.GetInteger` alinhado aos irmãos (default, não raise) | ⚠️ mudança documentada |
| README: nota Linux64 atualizada (duplicidade de `IEventMiddleware` já não existia) | docs |

## F2 — cirurgia no TJsonBuilder

1. **Aninhados sem roundtrip** (serializava→reparseava→re-serializava): -20% em profundidade 2; caminho antigo preservado quando há middlewares. Única mudança: separador cosmético `", "` → `","` (**JSON-equivalente verificado**).
2. **Listas**: RTTI `Add`/`Create` resolvido 1× por lista (era por item); leak em falha corrigido.

## F3 — Dataset + suíte de testes JSON

1. **Conversor Dataset**: datas reativadas (estavam comentadas → caíam em string por locale, quebrando round-trip ISO); `AClearFirst` deleta de verdade (era Close/Open); `CompareRecordWithJSON` implementado (corpo estava 100% comentado — sempre retornava "nenhuma diferença").
2. **Suíte de testes JSON criada**: as 11 units de teste eram ÓRFÃS (zero cobertura automatizada do lado JSON). Novo projeto DUnitX com 10 units — **102/102 verdes** (a 11ª era simulação sem valor, excluída e documentada). De quebra: os 22 testes do Composer tinham bug de ciclo de vida (classe+Free em objeto refcontado) — corrigidos.

## Validação

- ✅ **102/102** testes JSON (novos) · **104/104** Schema · **15/15** Fase A · **8/8** Fase D
- ✅ Harnesses serializer/schema/composer **byte-idênticos** · builder **JSON-equivalente**

🤖 Generated with [Claude Code](https://claude.com/claude-code)