### PR TITLE
perf/feat: G1-G3 — pendências deliberadas da auditoria (item 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ JsonFlow was also benchmarked against the popular [X-SuperObject](https://github
 
 ### 🐧 Cross-Platform Build — Win32 / Win64 / Linux64
 
-> **Win32 / Win64:** ✅ verified (2026-06-20, real production backend). **Linux64:** the units used by the backend compile and run on Linux. The previously documented `IEventMiddleware` duplicate declaration has been resolved (`JsonFlow.Interfaces` is the canonical unit); a full standalone Linux build re-verification is the remaining follow-up.
+> **Win32 / Win64:** ✅ verified (2026-06-20, real production backend). **Linux64:** ✅ all 79 framework units compile standalone with `dcclinux64` (verified 2026-07-07, RAD Studio 37.0; the Horse middleware integration is out of scope as an external dependency). Linking a final executable still requires a Linux SDK, as described below.
 
 **Building a consumer app for Linux64:** install the Linux 64-bit platform (RAD Studio GetIt / `GetItCmd -if=delphi_linux -ae`), provide a Linux SDK (RAD Studio SDK Manager + PAServer, **or** a sysroot assembled from a WSL/Linux toolchain passed to `dcclinux64` via `--syslibroot` / `--libpath`), then compile with `dcclinux64`.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -55,7 +55,7 @@ O JsonFlow também foi comparado com a popular biblioteca [X-SuperObject](https:
 
 ### 🐧 Build Multiplataforma — Win32 / Win64 / Linux64
 
-> **Win32 / Win64:** ✅ verificado (2026-06-20, backend real em produção). **Linux64:** as units usadas pelo backend compilam e rodam no Linux. A duplicidade de `IEventMiddleware` documentada anteriormente foi resolvida (`JsonFlow.Interfaces` é a unit canônica); re-verificar o build standalone completo no Linux é o follow-up restante.
+> **Win32 / Win64:** ✅ verificado (2026-06-20, backend real em produção). **Linux64:** ✅ as 79 units do framework compilam standalone com `dcclinux64` (verificado 2026-07-07, RAD Studio 37.0; integração Horse fora do escopo por ser dependência externa). Para linkar o executável final é necessário um SDK Linux, conforme abaixo.
 
 **Para buildar um app consumidor no Linux64:** instale a plataforma Linux 64-bit (RAD Studio GetIt / `GetItCmd -if=delphi_linux -ae`), forneça um SDK Linux (SDK Manager do RAD Studio + PAServer, **ou** um sysroot montado de um toolchain WSL/Linux passado ao `dcclinux64` via `--syslibroot` / `--libpath`), e compile com `dcclinux64`.
 

--- a/Source/Core/JsonFlow.Builders.pas
+++ b/Source/Core/JsonFlow.Builders.pas
@@ -533,12 +533,19 @@ end;
 procedure TJsonBuilder.AddMiddleware(
   const AEventMiddleware: IEventMiddleware);
 var
+  LRef: IEventMiddleware;
   LGetMw: IGetValueMiddleware;
   LSetMw: ISetValueMiddleware;
   LHasContract: Boolean;
 begin
   if not Assigned(AEventMiddleware) then
     raise EArgumentNilException.Create('Middleware cannot be nil');
+
+  // Segura uma referência antes dos Supports: com const + objeto recém-criado
+  // o refcount chega em 0 — um QueryInterface que falha seguido de raise
+  // vazava o objeto, e a ordem dos Supports ficava sensível a destruição
+  // prematura (mesmo bug corrigido no TJSONSerializer.AddMiddleware).
+  LRef := AEventMiddleware;
 
   // Contrato validado no REGISTRO: implementar só o marcador IEventMiddleware
   // seria silenciosamente inútil — falha aqui, não em runtime silencioso.
@@ -547,12 +554,12 @@ begin
   LHasContract := False;
   TMonitor.Enter(FMiddlwareLock);
   try
-    if Supports(AEventMiddleware, IGetValueMiddleware, LGetMw) then
+    if Supports(LRef, IGetValueMiddleware, LGetMw) then
     begin
       FGetMiddlewares := FGetMiddlewares + [LGetMw];
       LHasContract := True;
     end;
-    if Supports(AEventMiddleware, ISetValueMiddleware, LSetMw) then
+    if Supports(LRef, ISetValueMiddleware, LSetMw) then
     begin
       FSetMiddlewares := FSetMiddlewares + [LSetMw];
       LHasContract := True;

--- a/Source/JSON/IO/JsonFlow.Serializer.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.pas
@@ -123,6 +123,9 @@ implementation
 uses
   System.DateUtils;
 
+const
+  C_DEFAULT_FLOAT_FORMAT = '0.##########';
+
 { TJSONSerializerOptions }
 
 class function TJSONSerializerOptions.Default: TJSONSerializerOptions;
@@ -133,7 +136,7 @@ begin
   Result.ProcessAttributes := False;
   Result.IgnoreNullValues := False;
   Result.DateTimeFormat := 'yyyy-mm-dd"T"hh:nn:ss.zzz"Z"';
-  Result.FloatFormat := '0.##########';
+  Result.FloatFormat := C_DEFAULT_FLOAT_FORMAT;
   Result.MaxDepth := 100;
 end;
 
@@ -805,7 +808,14 @@ begin
         else
         begin
           LDouble := AValue.AsExtended;
-          ABuilder.Append(FormatFloat(FOptions.FloatFormat, LDouble, FFormatSettings));
+          // Double integral com a máscara padrão produz os mesmos dígitos que
+          // Int64: emite direto sem reparsear a máscara (~8× mais rápido).
+          // Acima de 1E15 a máscara pode arredondar diferente do Int64 exato.
+          if (Frac(LDouble) = 0) and (System.Abs(LDouble) < 1E15) and
+             (FOptions.FloatFormat = C_DEFAULT_FLOAT_FORMAT) then
+            ABuilder.Append(Trunc(LDouble))
+          else
+            ABuilder.Append(FormatFloat(FOptions.FloatFormat, LDouble, FFormatSettings));
         end;
       end;
     tkChar, tkWChar, tkLString, tkWString, tkUString:

--- a/Source/JSON/IO/JsonFlow.Serializer.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.pas
@@ -34,6 +34,29 @@ uses
 
 type
   /// <summary>
+  /// Classificação de coleções suportadas nativamente pelo serializador.
+  /// Coleções serializam como array JSON — sem isso, TObjectList/TStrings/
+  /// TCollection viravam um "saco de propriedades" ({"Capacity":...,"Count":...}).
+  /// </summary>
+  TSerializerCollectionKind = (sckNone, sckStrings, sckCollection, sckClassicList, sckGenericList);
+
+  /// <summary>
+  /// Entrada do cache de tipo: RTTI + propriedades legíveis + classificação de
+  /// coleção com os métodos resolvidos uma única vez por classe.
+  /// </summary>
+  TSerializerTypeInfo = record
+    RttiType: TRttiType;
+    Props: TList<TRttiProperty>;
+    CollectionKind: TSerializerCollectionKind;
+    // sckGenericList (TList<T>/TObjectList<T>): resolvidos no cache
+    ToArrayMethod: TRttiMethod;   // serialização
+    AddMethod: TRttiMethod;       // deserialização
+    ClearMethod: TRttiMethod;     // deserialização
+    ItemCreate: TRttiMethod;      // construtor do item (apenas itens classe)
+    ItemMetaclass: TClass;
+  end;
+
+  /// <summary>
   /// Opções avançadas de serialização
   /// </summary>
   TJSONSerializerOptions = record
@@ -63,9 +86,17 @@ type
     FAttributeHelper: TJSONAttributeHelper;
   private
     FContext: TRttiContext;
-    FTypeCache: TDictionary<TClass, TPair<TRttiType, TList<TRttiProperty>>>;
+    FTypeCache: TDictionary<TClass, TSerializerTypeInfo>;
     procedure _Log(const AMessage: string);
-    function _GetCachedType(AClass: TClass): TPair<TRttiType, TList<TRttiProperty>>;
+    function _GetCachedType(AClass: TClass): TSerializerTypeInfo;
+    function _ResolveListItemType(const AListType: TRttiType): TRttiType;
+    function _CollectionToElement(AObject: TObject; const AInfo: TSerializerTypeInfo;
+      const AStoreClassName: Boolean): IJSONElement;
+    function _CollectionFromElement(AObject: TObject; const AInfo: TSerializerTypeInfo;
+      const AArray: IJSONArray): Boolean;
+    procedure _WriteCollection(AObject: TObject; const AInfo: TSerializerTypeInfo;
+      ABuilder: TStringBuilder; const AStoreClassName: Boolean);
+    procedure _AppendElement(const AElement: IJSONElement; ABuilder: TStringBuilder);
     procedure _JSONToProperty(const AProperty: TRttiProperty; const AInstance: TObject;
       const AElement: IJSONElement);
     function _JSONFromProperty(const AProperty: TRttiProperty; const AInstance: TObject;
@@ -147,7 +178,7 @@ begin
   inherited Create;
   FLogProc := nil;
   FContext := TRttiContext.Create;
-  FTypeCache := TDictionary<TClass, TPair<TRttiType, TList<TRttiProperty>>>.Create;
+  FTypeCache := TDictionary<TClass, TSerializerTypeInfo>.Create;
   FMiddlewares := TList<IEventMiddleware>.Create;
   FFormatSettings := TFormatSettings.Create('en-US');
   FFormatSettings.ShortDateFormat := 'yyyy-mm-dd';
@@ -170,7 +201,7 @@ begin
   inherited Create;
   FLogProc := nil;
   FContext := TRttiContext.Create;
-  FTypeCache := TDictionary<TClass, TPair<TRttiType, TList<TRttiProperty>>>.Create;
+  FTypeCache := TDictionary<TClass, TSerializerTypeInfo>.Create;
   FMiddlewares := TList<IEventMiddleware>.Create;
   FFormatSettings := TFormatSettings.Create('en-US');
   FFormatSettings.ShortDateFormat := 'yyyy-mm-dd';
@@ -188,10 +219,10 @@ end;
 
 destructor TJSONSerializer.Destroy;
 var
-  LPair: TPair<TClass, TPair<TRttiType, TList<TRttiProperty>>>;
+  LPair: TPair<TClass, TSerializerTypeInfo>;
 begin
   for LPair in FTypeCache do
-    LPair.Value.Value.Free;
+    LPair.Value.Props.Free;
   FAttributeHelper.Free;
   FCircularRefManager.Free;
   FMiddlewares.Free;
@@ -206,11 +237,12 @@ begin
     FLogProc(AMessage);
 end;
 
-function TJSONSerializer._GetCachedType(AClass: TClass): TPair<TRttiType, TList<TRttiProperty>>;
+function TJSONSerializer._GetCachedType(AClass: TClass): TSerializerTypeInfo;
 var
   LRttiType: TRttiType;
   LProperties: TList<TRttiProperty>;
   LProp: TRttiProperty;
+  LItemType: TRttiType;
 begin
   // TryGetValue único no hit — antes eram 2-3 buscas no dicionário por objeto
   // (ContainsKey no _CacheType + FTypeCache[LClass] no chamador).
@@ -220,21 +252,246 @@ begin
   LRttiType := FContext.GetType(AClass);
   if not Assigned(LRttiType) then
     raise EInvalidOperation.Create('RTTI not available for class ' + AClass.ClassName);
+
+  Result := Default(TSerializerTypeInfo);
+  Result.RttiType := LRttiType;
+
+  // Classificação de coleção — uma vez por classe; os hot paths só comparam
+  // o enum. TStack/TQueue/TDictionary ficam de fora (sem semântica de array
+  // ordenado estável).
+  if AClass.InheritsFrom(TStrings) then
+    Result.CollectionKind := sckStrings
+  else if AClass.InheritsFrom(TCollection) then
+    Result.CollectionKind := sckCollection
+  else if AClass.InheritsFrom(TList) then
+    Result.CollectionKind := sckClassicList
+  else if Pos('List<', AClass.ClassName) > 0 then
+  begin
+    Result.ToArrayMethod := LRttiType.GetMethod('ToArray');
+    if Assigned(Result.ToArrayMethod) then
+    begin
+      Result.CollectionKind := sckGenericList;
+      Result.AddMethod := LRttiType.GetMethod('Add');
+      Result.ClearMethod := LRttiType.GetMethod('Clear');
+      LItemType := _ResolveListItemType(LRttiType);
+      if Assigned(LItemType) and LItemType.IsInstance then
+      begin
+        Result.ItemMetaclass := LItemType.AsInstance.MetaclassType;
+        Result.ItemCreate := LItemType.GetMethod('Create');
+      end;
+    end;
+  end;
+
   LProperties := TList<TRttiProperty>.Create;
   try
     for LProp in LRttiType.GetProperties do
     begin
       if LProp.IsReadable then
       begin
+        // Plumbing do TCollectionItem (Collection/ID/Index/DisplayName) fica
+        // de fora: 'Collection' é back-reference para a coleção dona —
+        // serializá-la recursava infinitamente (item → coleção → item...).
+        if AClass.InheritsFrom(TCollectionItem) and
+           (LProp.Parent.Handle = TypeInfo(TCollectionItem)) then
+          Continue;
         LProperties.Add(LProp);
       end;
     end;
-    Result := TPair<TRttiType, TList<TRttiProperty>>.Create(LRttiType, LProperties);
+    Result.Props := LProperties;
     FTypeCache.Add(AClass, Result);
   except
     LProperties.Free;
     raise;
   end;
+end;
+
+function TJSONSerializer._ResolveListItemType(const AListType: TRttiType): TRttiType;
+var
+  LName: string;
+  LPosI, LPosF: Integer;
+begin
+  // 'TObjectList<Unit.TItem>' → FindType('Unit.TItem') — o argumento genérico
+  // já vem qualificado no nome do tipo.
+  Result := nil;
+  LName := AListType.ToString;
+  LPosI := Pos('<', LName);
+  if LPosI <= 0 then
+    Exit;
+  LPosF := LastDelimiter('>', LName);
+  if LPosF <= LPosI then
+    Exit;
+  Result := FContext.FindType(Copy(LName, LPosI + 1, LPosF - LPosI - 1));
+end;
+
+function TJSONSerializer._CollectionToElement(AObject: TObject; const AInfo: TSerializerTypeInfo;
+  const AStoreClassName: Boolean): IJSONElement;
+var
+  LArray: IJSONArray;
+  LFor: Integer;
+  LItem: TObject;
+begin
+  case AInfo.CollectionKind of
+    sckStrings:
+      begin
+        LArray := TJSONArray.Create;
+        for LFor := 0 to TStrings(AObject).Count - 1 do
+          LArray.Add(TJSONValueString.Create(TStrings(AObject).Strings[LFor]));
+        Result := LArray;
+      end;
+    sckCollection:
+      begin
+        LArray := TJSONArray.Create;
+        for LFor := 0 to TCollection(AObject).Count - 1 do
+          LArray.Add(FromObject(TCollection(AObject).Items[LFor], AStoreClassName));
+        Result := LArray;
+      end;
+    sckClassicList:
+      begin
+        LArray := TJSONArray.Create;
+        for LFor := 0 to TList(AObject).Count - 1 do
+        begin
+          LItem := TObject(TList(AObject).List[LFor]);
+          if Assigned(LItem) then
+            LArray.Add(FromObject(LItem, AStoreClassName))
+          else
+            LArray.Add(TJSONValueNull.Create);
+        end;
+        Result := LArray;
+      end;
+    sckGenericList:
+      // ToArray → TValue (tkDynArray) reaproveita a serialização de arrays,
+      // cobrindo listas de qualquer elemento (classe, número, string...).
+      Result := _SerializeTValue(AInfo.ToArrayMethod.Invoke(AObject, []), AStoreClassName);
+  else
+    Result := TJSONValueNull.Create;
+  end;
+end;
+
+function TJSONSerializer._CollectionFromElement(AObject: TObject; const AInfo: TSerializerTypeInfo;
+  const AArray: IJSONArray): Boolean;
+var
+  LFor: Integer;
+  LItem: TObject;
+  LValueIntf: IJSONValue;
+begin
+  Result := False;
+  case AInfo.CollectionKind of
+    sckStrings:
+      begin
+        TStrings(AObject).BeginUpdate;
+        try
+          TStrings(AObject).Clear;
+          for LFor := 0 to AArray.Count - 1 do
+            if Supports(AArray.GetItem(LFor), IJSONValue, LValueIntf) then
+              TStrings(AObject).Add(LValueIntf.AsString);
+        finally
+          TStrings(AObject).EndUpdate;
+        end;
+        Result := True;
+      end;
+    sckCollection:
+      begin
+        TCollection(AObject).Clear;
+        for LFor := 0 to AArray.Count - 1 do
+        begin
+          LItem := TCollection(AObject).Add;
+          if not ToObject(AArray.GetItem(LFor), LItem) then
+            Exit;
+        end;
+        Result := True;
+      end;
+    sckGenericList:
+      begin
+        if not Assigned(AInfo.ItemMetaclass) or not Assigned(AInfo.AddMethod) or
+           not Assigned(AInfo.ItemCreate) then
+          raise EArgumentException.Create(
+            'Cannot deserialize into ' + AObject.ClassName +
+            ' (only lists of classes are supported)');
+        if Assigned(AInfo.ClearMethod) then
+          AInfo.ClearMethod.Invoke(AObject, []);
+        for LFor := 0 to AArray.Count - 1 do
+        begin
+          // Invoke do construtor na CLASSE: aloca e roda o construtor real
+          // numa única chamada (mesmo padrão do JsonToObjectList do builder).
+          LItem := AInfo.ItemCreate.Invoke(AInfo.ItemMetaclass, []).AsObject;
+          try
+            if not ToObject(AArray.GetItem(LFor), LItem) then
+            begin
+              LItem.Free;
+              Exit;
+            end;
+          except
+            LItem.Free;
+            raise;
+          end;
+          AInfo.AddMethod.Invoke(AObject, [LItem]);
+        end;
+        Result := True;
+      end;
+    sckClassicList:
+      raise EArgumentException.Create(
+        'Cannot deserialize into classic TList (element type unknown); use TObjectList<T>');
+  end;
+end;
+
+procedure TJSONSerializer._WriteCollection(AObject: TObject; const AInfo: TSerializerTypeInfo;
+  ABuilder: TStringBuilder; const AStoreClassName: Boolean);
+var
+  LFor: Integer;
+  LItem: TObject;
+begin
+  case AInfo.CollectionKind of
+    sckStrings:
+      begin
+        ABuilder.Append('[');
+        for LFor := 0 to TStrings(AObject).Count - 1 do
+        begin
+          if LFor > 0 then
+            ABuilder.Append(',');
+          ABuilder.Append('"');
+          _AppendEscapedString(TStrings(AObject).Strings[LFor], ABuilder);
+          ABuilder.Append('"');
+        end;
+        ABuilder.Append(']');
+      end;
+    sckCollection:
+      begin
+        ABuilder.Append('[');
+        for LFor := 0 to TCollection(AObject).Count - 1 do
+        begin
+          if LFor > 0 then
+            ABuilder.Append(',');
+          _WriteObject(TCollection(AObject).Items[LFor], ABuilder, AStoreClassName);
+        end;
+        ABuilder.Append(']');
+      end;
+    sckClassicList:
+      begin
+        ABuilder.Append('[');
+        for LFor := 0 to TList(AObject).Count - 1 do
+        begin
+          if LFor > 0 then
+            ABuilder.Append(',');
+          LItem := TObject(TList(AObject).List[LFor]);
+          _WriteObject(LItem, ABuilder, AStoreClassName); // nil → 'null'
+        end;
+        ABuilder.Append(']');
+      end;
+    sckGenericList:
+      _WriteTValue(AInfo.ToArrayMethod.Invoke(AObject, []), ABuilder, AStoreClassName);
+  end;
+end;
+
+procedure TJSONSerializer._AppendElement(const AElement: IJSONElement; ABuilder: TStringBuilder);
+var
+  LCompact: IJSONCompactWriter;
+begin
+  if not Assigned(AElement) then
+    ABuilder.Append('null')
+  else if Supports(AElement, IJSONCompactWriter, LCompact) then
+    LCompact.AppendCompactJSON(ABuilder)
+  else
+    ABuilder.Append(AElement.AsJSON(False));
 end;
 
 function TJSONSerializer._JSONFromProperty(const AProperty: TRttiProperty; const AInstance: TObject;
@@ -560,7 +817,10 @@ begin
     tkClass:
       begin
         LObject := AProperty.GetValue(AInstance).AsObject;
-        if Assigned(LObject) and Supports(AElement, IJSONObject) then
+        // IJSONArray também: propriedades de coleção (TObjectList/TStrings/
+        // TCollection) chegam como array JSON e o ToObject as despacha.
+        if Assigned(LObject) and
+           (Supports(AElement, IJSONObject) or Supports(AElement, IJSONArray)) then
           ToObject(AElement, LObject);
       end;
     tkDynArray:
@@ -620,7 +880,7 @@ end;
 function TJSONSerializer.FromObject(AObject: TObject; AStoreClassName: Boolean): IJSONElement;
 var
   LClass: TClass;
-  LTypeInfo: TPair<TRttiType, TList<TRttiProperty>>;
+  LTypeInfo: TSerializerTypeInfo;
   LProp: TRttiProperty;
   LJsonObj: IJSONObject;
   LElement: IJSONElement;
@@ -632,12 +892,15 @@ begin
   LClass := AObject.ClassType;
   LTypeInfo := _GetCachedType(LClass);
 
+  if LTypeInfo.CollectionKind <> sckNone then
+    Exit(_CollectionToElement(AObject, LTypeInfo, AStoreClassName));
+
   LJsonObj := TJSONObject.Create;
   try
     if AStoreClassName then
       LJsonObj.Add('$class', TJSONValueString.Create(LClass.ClassName));
 
-    for LProp in LTypeInfo.Value do
+    for LProp in LTypeInfo.Props do
     begin
       if FOptions.ProcessAttributes then
       begin
@@ -676,22 +939,30 @@ begin
 end;
 
 procedure TJSONSerializer.AddMiddleware(const AMiddleware: IEventMiddleware);
+var
+  LRef: IEventMiddleware;
 begin
   if not Assigned(AMiddleware) then
     raise EArgumentNilException.Create('Middleware cannot be nil');
-  if not (Supports(AMiddleware, IGetValueMiddleware) or
-          Supports(AMiddleware, ISetValueMiddleware)) then
+  // Segura uma referência ANTES de validar: com parâmetro const + objeto
+  // recém-criado (AddMiddleware(TMyMw.Create)) o refcount chega em 0 e o
+  // Supports de validação (QueryInterface + release do temporário) destruía
+  // o middleware — o Add então guardava um ponteiro dangling.
+  LRef := AMiddleware;
+  if not (Supports(LRef, IGetValueMiddleware) or
+          Supports(LRef, ISetValueMiddleware)) then
     raise EArgumentException.Create(
       'Middleware must implement IGetValueMiddleware and/or ISetValueMiddleware ' +
       '(implementing only the IEventMiddleware marker has no effect)');
-  FMiddlewares.Add(AMiddleware);
+  FMiddlewares.Add(LRef);
 end;
 
 function TJSONSerializer.ToObject(const AElement: IJSONElement; AObject: TObject): Boolean;
 var
   LClass: TClass;
-  LTypeInfo: TPair<TRttiType, TList<TRttiProperty>>;
+  LTypeInfo: TSerializerTypeInfo;
   LJsonObj: IJSONObject;
+  LJsonArr: IJSONArray;
   LProp: TRttiProperty;
   LKey: String;
   LElement: IJSONElement;
@@ -702,13 +973,20 @@ begin
   if not Assigned(AElement) then
     raise EArgumentNilException.Create('Element cannot be nil');
 
-  if not Supports(AElement, IJSONObject, LJsonObj) then
-    raise EArgumentException.Create('Element must be a JSON object');
-
   LClass := AObject.ClassType;
   LTypeInfo := _GetCachedType(LClass);
 
-  for LProp in LTypeInfo.Value do
+  if LTypeInfo.CollectionKind <> sckNone then
+  begin
+    if not Supports(AElement, IJSONArray, LJsonArr) then
+      raise EArgumentException.Create('Element must be a JSON array for collection ' + LClass.ClassName);
+    Exit(_CollectionFromElement(AObject, LTypeInfo, LJsonArr));
+  end;
+
+  if not Supports(AElement, IJSONObject, LJsonObj) then
+    raise EArgumentException.Create('Element must be a JSON object');
+
+  for LProp in LTypeInfo.Props do
   begin
     if FOptions.ProcessAttributes then
     begin
@@ -868,11 +1146,17 @@ end;
 procedure TJSONSerializer._WriteObject(AObject: TObject; ABuilder: TStringBuilder; const AStoreClassName: Boolean);
 var
   LClass: TClass;
-  LTypeInfo: TPair<TRttiType, TList<TRttiProperty>>;
+  LTypeInfo: TSerializerTypeInfo;
   LProp: TRttiProperty;
   LPropName: string;
   LValue: TValue;
   LFirst: Boolean;
+  LFor: Integer;
+  LHandled: Boolean;
+  LBreak: Boolean;
+  LResult: Variant;
+  LGetMiddle: IGetValueMiddleware;
+  LConverter: IJSONPropertyConverter;
 begin
   if not Assigned(AObject) then
   begin
@@ -882,6 +1166,12 @@ begin
 
   LClass := AObject.ClassType;
   LTypeInfo := _GetCachedType(LClass);
+
+  if LTypeInfo.CollectionKind <> sckNone then
+  begin
+    _WriteCollection(AObject, LTypeInfo, ABuilder, AStoreClassName);
+    Exit;
+  end;
 
   ABuilder.Append('{');
   LFirst := True;
@@ -894,7 +1184,7 @@ begin
     LFirst := False;
   end;
 
-  for LProp in LTypeInfo.Value do
+  for LProp in LTypeInfo.Props do
   begin
     LValue := LProp.GetValue(AObject);
 
@@ -920,7 +1210,39 @@ begin
     ABuilder.Append(LPropName);
     ABuilder.Append('":');
 
-    _WriteTValue(LValue, ABuilder, AStoreClassName);
+    // Converters e middlewares honrados também no caminho stream — antes o
+    // SerializeToString os ignorava silenciosamente (só o FromObject/DOM
+    // interceptava). Mesma ordem do _JSONFromProperty: converter → middleware
+    // → valor. Guardas mantêm custo zero sem attributes/middlewares.
+    LHandled := False;
+    if FOptions.ProcessAttributes then
+    begin
+      LConverter := TJSONAttributeHelper.GetCustomConverter(LProp);
+      if Assigned(LConverter) then
+      begin
+        _AppendElement(LConverter.ToJSON(LValue, LProp), ABuilder);
+        LHandled := True;
+      end;
+    end;
+    if not LHandled and (FMiddlewares.Count > 0) then
+    begin
+      for LFor := 0 to FMiddlewares.Count - 1 do
+      begin
+        if Supports(FMiddlewares[LFor], IGetValueMiddleware, LGetMiddle) then
+        begin
+          LBreak := False;
+          LGetMiddle.GetValue(AObject, LProp, LResult, LBreak);
+          if LBreak then
+          begin
+            _AppendElement(_JSONToElement(LResult), ABuilder);
+            LHandled := True;
+            Break;
+          end;
+        end;
+      end;
+    end;
+    if not LHandled then
+      _WriteTValue(LValue, ABuilder, AStoreClassName);
   end;
   ABuilder.Append('}');
 end;

--- a/Tests/JSON/IO/JsonFlow.TestsSerializerCollections.pas
+++ b/Tests/JSON/IO/JsonFlow.TestsSerializerCollections.pas
@@ -1,0 +1,405 @@
+unit JsonFlow.TestsSerializerCollections;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  System.Rtti,
+  System.SysUtils,
+  System.Classes,
+  System.Generics.Collections,
+  JsonFlow.Interfaces,
+  JsonFlow.Value,
+  JsonFlow.Objects,
+  JsonFlow.Arrays,
+  JsonFlow.Reader,
+  JsonFlow.Serializer;
+
+type
+  TCollItem = class
+  private
+    FName: String;
+    FAge: Integer;
+  public
+    property Name: String read FName write FName;
+    property Age: Integer read FAge write FAge;
+  end;
+
+  TCollOwner = class
+  private
+    FTitle: String;
+    FItems: TObjectList<TCollItem>;
+    FTags: TStringList;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    property Title: String read FTitle write FTitle;
+    property Items: TObjectList<TCollItem> read FItems write FItems;
+    property Tags: TStringList read FTags write FTags;
+  end;
+
+  TPersonItem = class(TCollectionItem)
+  private
+    FName: String;
+  published
+    property Name: String read FName write FName;
+  end;
+
+  // Middleware que substitui o valor da propriedade 'Name' — usado para
+  // provar que o caminho stream (SerializeToString) honra middlewares.
+  TMaskNameMiddleware = class(TInterfacedObject, IEventMiddleware, IGetValueMiddleware)
+  public
+    procedure GetValue(const AInstance: TObject; const AProperty: TRttiProperty;
+      var AValue: Variant; var ABreak: Boolean);
+  end;
+
+  [TestFixture]
+  TJSONSerializerCollectionTests = class
+  public
+    [Test]
+    procedure TestObjectListTopLevelDOM;
+    [Test]
+    procedure TestObjectListTopLevelStream;
+    [Test]
+    procedure TestObjectListPropertyBothPaths;
+    [Test]
+    procedure TestStringListProperty;
+    [Test]
+    procedure TestGenericListOfInteger;
+    [Test]
+    procedure TestClassicTList;
+    [Test]
+    procedure TestTCollection;
+    [Test]
+    procedure TestEmptyCollections;
+    [Test]
+    procedure TestRoundtripObjectListProperty;
+    [Test]
+    procedure TestRoundtripTopLevelObjectList;
+    [Test]
+    procedure TestDeserializeClassicTListRaises;
+    [Test]
+    procedure TestStreamHonorsGetMiddleware;
+  end;
+
+implementation
+
+{ TCollOwner }
+
+constructor TCollOwner.Create;
+begin
+  FItems := TObjectList<TCollItem>.Create(True);
+  FTags := TStringList.Create;
+end;
+
+destructor TCollOwner.Destroy;
+begin
+  FTags.Free;
+  FItems.Free;
+  inherited;
+end;
+
+{ TMaskNameMiddleware }
+
+procedure TMaskNameMiddleware.GetValue(const AInstance: TObject;
+  const AProperty: TRttiProperty; var AValue: Variant; var ABreak: Boolean);
+begin
+  if AProperty.Name = 'Name' then
+  begin
+    AValue := '***';
+    ABreak := True;
+  end;
+end;
+
+function NewItem(const AName: String; AAge: Integer): TCollItem;
+begin
+  Result := TCollItem.Create;
+  Result.Name := AName;
+  Result.Age := AAge;
+end;
+
+{ TJSONSerializerCollectionTests }
+
+procedure TJSONSerializerCollectionTests.TestObjectListTopLevelDOM;
+var
+  LSerializer: TJSONSerializer;
+  LList: TObjectList<TCollItem>;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LList := TObjectList<TCollItem>.Create(True);
+    try
+      LList.Add(NewItem('Ana', 30));
+      LList.Add(NewItem('Bia', 25));
+      Assert.AreEqual('[{"Name":"Ana","Age":30},{"Name":"Bia","Age":25}]',
+        LSerializer.FromObject(LList).AsJSON);
+    finally
+      LList.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestObjectListTopLevelStream;
+var
+  LSerializer: TJSONSerializer;
+  LList: TObjectList<TCollItem>;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LList := TObjectList<TCollItem>.Create(True);
+    try
+      LList.Add(NewItem('Ana', 30));
+      LList.Add(NewItem('Bia', 25));
+      Assert.AreEqual('[{"Name":"Ana","Age":30},{"Name":"Bia","Age":25}]',
+        LSerializer.SerializeToString(LList));
+    finally
+      LList.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestObjectListPropertyBothPaths;
+var
+  LSerializer: TJSONSerializer;
+  LOwner: TCollOwner;
+  LExpected: String;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LOwner := TCollOwner.Create;
+    try
+      LOwner.Title := 'Time';
+      LOwner.Items.Add(NewItem('Ana', 30));
+      LOwner.Tags.Add('a');
+      LOwner.Tags.Add('b');
+      LExpected := '{"Title":"Time","Items":[{"Name":"Ana","Age":30}],"Tags":["a","b"]}';
+      Assert.AreEqual(LExpected, LSerializer.FromObject(LOwner).AsJSON, 'caminho DOM');
+      Assert.AreEqual(LExpected, LSerializer.SerializeToString(LOwner), 'caminho stream');
+    finally
+      LOwner.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestStringListProperty;
+var
+  LSerializer: TJSONSerializer;
+  LStrings: TStringList;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LStrings := TStringList.Create;
+    try
+      LStrings.Add('um');
+      LStrings.Add('com "aspas"');
+      Assert.AreEqual('["um","com \"aspas\""]', LSerializer.SerializeToString(LStrings));
+      Assert.AreEqual('["um","com \"aspas\""]', LSerializer.FromObject(LStrings).AsJSON);
+    finally
+      LStrings.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestGenericListOfInteger;
+var
+  LSerializer: TJSONSerializer;
+  LList: TList<Integer>;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LList := TList<Integer>.Create;
+    try
+      LList.AddRange([1, 2, 3]);
+      Assert.AreEqual('[1,2,3]', LSerializer.SerializeToString(LList));
+      Assert.AreEqual('[1,2,3]', LSerializer.FromObject(LList).AsJSON);
+    finally
+      LList.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestClassicTList;
+var
+  LSerializer: TJSONSerializer;
+  LList: TList;
+  LItem: TCollItem;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LList := TList.Create;
+    LItem := NewItem('Ana', 30);
+    try
+      LList.Add(LItem);
+      Assert.AreEqual('[{"Name":"Ana","Age":30}]', LSerializer.SerializeToString(LList));
+    finally
+      LItem.Free;
+      LList.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestTCollection;
+var
+  LSerializer: TJSONSerializer;
+  LColl: TCollection;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LColl := TCollection.Create(TPersonItem);
+    try
+      TPersonItem(LColl.Add).Name := 'Ana';
+      TPersonItem(LColl.Add).Name := 'Bia';
+      Assert.AreEqual('[{"Name":"Ana"},{"Name":"Bia"}]',
+        LSerializer.SerializeToString(LColl));
+    finally
+      LColl.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestEmptyCollections;
+var
+  LSerializer: TJSONSerializer;
+  LList: TObjectList<TCollItem>;
+  LStrings: TStringList;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LList := TObjectList<TCollItem>.Create(True);
+    LStrings := TStringList.Create;
+    try
+      Assert.AreEqual('[]', LSerializer.SerializeToString(LList));
+      Assert.AreEqual('[]', LSerializer.FromObject(LStrings).AsJSON);
+    finally
+      LStrings.Free;
+      LList.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestRoundtripObjectListProperty;
+var
+  LSerializer: TJSONSerializer;
+  LReader: TJSONReader;
+  LSource, LTarget: TCollOwner;
+  LJson: String;
+begin
+  LSerializer := TJSONSerializer.Create;
+  LReader := TJSONReader.Create;
+  try
+    LSource := TCollOwner.Create;
+    LTarget := TCollOwner.Create;
+    try
+      LSource.Title := 'Time';
+      LSource.Items.Add(NewItem('Ana', 30));
+      LSource.Items.Add(NewItem('Bia', 25));
+      LSource.Tags.Add('x');
+      LJson := LSerializer.SerializeToString(LSource);
+      Assert.IsTrue(LSerializer.ToObject(LReader.Read(LJson), LTarget));
+      Assert.AreEqual('Time', LTarget.Title);
+      Assert.AreEqual(2, LTarget.Items.Count);
+      Assert.AreEqual('Ana', LTarget.Items[0].Name);
+      Assert.AreEqual(30, LTarget.Items[0].Age);
+      Assert.AreEqual('Bia', LTarget.Items[1].Name);
+      Assert.AreEqual(1, LTarget.Tags.Count);
+      Assert.AreEqual('x', LTarget.Tags[0]);
+    finally
+      LTarget.Free;
+      LSource.Free;
+    end;
+  finally
+    LReader.Free;
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestRoundtripTopLevelObjectList;
+var
+  LSerializer: TJSONSerializer;
+  LSource, LTarget: TObjectList<TCollItem>;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LSource := TObjectList<TCollItem>.Create(True);
+    LTarget := TObjectList<TCollItem>.Create(True);
+    try
+      LSource.Add(NewItem('Ana', 30));
+      LTarget.Add(NewItem('Velho', 99)); // deve ser limpo pelo roundtrip
+      Assert.IsTrue(LSerializer.ToObject(LSerializer.FromObject(LSource), LTarget));
+      Assert.AreEqual(1, LTarget.Count);
+      Assert.AreEqual('Ana', LTarget[0].Name);
+      Assert.AreEqual(30, LTarget[0].Age);
+    finally
+      LTarget.Free;
+      LSource.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestDeserializeClassicTListRaises;
+var
+  LSerializer: TJSONSerializer;
+  LList: TList;
+  LArr: IJSONArray;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LList := TList.Create;
+    try
+      LArr := TJSONArray.Create;
+      Assert.WillRaise(
+        procedure
+        begin
+          LSerializer.ToObject(LArr, LList);
+        end, EArgumentException);
+    finally
+      LList.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+procedure TJSONSerializerCollectionTests.TestStreamHonorsGetMiddleware;
+var
+  LSerializer: TJSONSerializer;
+  LItem: TCollItem;
+begin
+  LSerializer := TJSONSerializer.Create;
+  try
+    LSerializer.AddMiddleware(TMaskNameMiddleware.Create);
+    LItem := NewItem('Ana', 30);
+    try
+      // Antes o caminho stream ignorava middlewares — só o DOM interceptava.
+      Assert.AreEqual('{"Name":"***","Age":30}', LSerializer.SerializeToString(LItem), 'stream');
+      Assert.AreEqual('{"Name":"***","Age":30}', LSerializer.FromObject(LItem).AsJSON, 'DOM');
+    finally
+      LItem.Free;
+    end;
+  finally
+    LSerializer.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TJSONSerializerCollectionTests);
+
+end.

--- a/Tests/JSON/JsonFlow.JSON.Tests.dpr
+++ b/Tests/JSON/JsonFlow.JSON.Tests.dpr
@@ -21,7 +21,8 @@ uses
   JsonFlow.TestsValue in 'Core\JsonFlow.TestsValue.pas',
   JsonFlow.TestsNavigator in 'IO\JsonFlow.TestsNavigator.pas',
   JsonFlow.TestsReader in 'IO\JsonFlow.TestsReader.pas',
-  JsonFlow.TestsSerializer in 'IO\JsonFlow.TestsSerializer.pas';
+  JsonFlow.TestsSerializer in 'IO\JsonFlow.TestsSerializer.pas',
+  JsonFlow.TestsSerializerCollections in 'IO\JsonFlow.TestsSerializerCollections.pas';
 
 var
   LRunner: ITestRunner;

--- a/Tests/JSON/JsonFlow.JSON.Tests.dproj
+++ b/Tests/JSON/JsonFlow.JSON.Tests.dproj
@@ -99,6 +99,7 @@
         <DCCReference Include="IO\JsonFlow.TestsNavigator.pas"/>
         <DCCReference Include="IO\JsonFlow.TestsReader.pas"/>
         <DCCReference Include="IO\JsonFlow.TestsSerializer.pas"/>
+        <DCCReference Include="IO\JsonFlow.TestsSerializerCollections.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>


### PR DESCRIPTION
## Resumo

Ataca as 4 pendências deliberadas registradas no fim da auditoria (PRs #41-#51), decididas com o Isaque:

### G1 — FormatFloat (decisão: só fast-path byte-idêntico)
- `Double` integral (< 1E15, máscara padrão) emite via `Append(Int64)` — **~8× mais rápido** nesse caso comum (ids, quantidades). Saída **byte-idêntica** (fuzz 2M valores, 0 divergências); `FloatFormat` customizado segue o caminho antigo.
- Documentado de investigação: a máscara padrão `0.##########` trunca >10 casas e serializa `1e-11` como `"0"` — mantido por decisão de compatibilidade.

### G2 — Lacunas do TJSONSerializer (decisão: fechar lacunas em vez de delegar o TJsonBuilder)
- **Coleções nativas**: `TObjectList<T>`/`TList<T>`/`TList`/`TStrings`/`TCollection` serializam como array JSON nos dois caminhos (DOM `FromObject` e stream `SerializeToString`), com roundtrip no `ToObject`. Antes saíam como saco de propriedades (`{"Capacity":...,"Count":...}`) sem erro. Classificação + métodos resolvidos 1× por classe no type-cache.
- **Middlewares/converters no stream**: `SerializeToString` agora honra `IGetValueMiddleware` e converters — antes só o caminho DOM interceptava (inconsistência silenciosa). Custo zero sem middlewares (guardas).
- **Bug 18 da auditoria (use-after-free)**: `AddMiddleware(TMyMw.Create)` — parâmetro `const` + refcount 0 fazia o `Supports` de validação **destruir o middleware** e o `Add` guardava ponteiro dangling (AV em runtime). Nunca visto porque nenhum teste exercitava o caminho. Serializer corrigido; builder endurecido (vazava na rejeição).
- A delegação total do TJsonBuilder foi registrada como **won't-do fundamentado**: mudaria a saída de qualquer objeto não-trivial (ClassName vs $class, floats, filtro writable vs readable, tkSet/tkVariant) — refactor de v2, não cirurgia.

### G3 — Linux64 re-verificado
- As **79 units** do framework compilam standalone com `dcclinux64` (RAD Studio 37.0, 2026-07-07). READMEs atualizados (nota de follow-up fechada).

### Avaliado e descartado (com números)
- **Reuso de contexto por nó no Schema**: 24.002 contextos/validação × 180ns = teto de 6% (~2-3% real com pool), risco alto de estado residual entre reusos. Não vale a pena após os paths incrementais do F1.

## Validação

- Suítes: **JSON 114/114** (+12 testes novos de coleções/middleware), **Schema 104/104**, zero leaks.
- A/B vs main (users-50k/customers-5k, metodologia da auditoria): **SHA256 idêntico** nos dois datasets, perf inalterada (±2ms).
- Fuzz de equivalência do fast-path de floats: 2M doubles integrais, 0 divergências vs máscara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)