### PR TITLE
docs: remove alegação de suporte a Lazarus (não verificada)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
   <img src="assets/logo.png" alt="JsonFlow Logo" width="380"/>
 </p>
 
-# JsonFlow — High-performance JSON serialization, dynamic manipulation, and Draft-7 Schema validation for Delphi/Lazarus
+# JsonFlow — High-performance JSON serialization, dynamic manipulation, and Draft-7 Schema validation for Delphi
 
 [![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
-[![Lazarus Compatible](https://img.shields.io/badge/Lazarus-Compatible-orange.svg)]()
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Security%20policy-success)](https://www.pubpascal.dev/packages/jsonflow)
 
@@ -21,7 +20,7 @@
 
 ---
 
-**JsonFlow** is a state-of-the-art, high-performance, and feature-rich JSON manipulation, serialization, and JSON Schema validation framework for Delphi and Lazarus. It provides an enterprise-ready toolkit that integrates high-speed object serialization, in-place dynamic JSON editing, and robust Draft 7 JSON Schema validation under a unified, elegant, and fluent API. Every hot path — parsing, RTTI marshalling, path-based editing, and schema validation — has been profiled and optimized against public, reproducible benchmarks, delivering native speeds for intensive web applications, APIs, and microservices.
+**JsonFlow** is a state-of-the-art, high-performance, and feature-rich JSON manipulation, serialization, and JSON Schema validation framework for Delphi. It provides an enterprise-ready toolkit that integrates high-speed object serialization, in-place dynamic JSON editing, and robust Draft 7 JSON Schema validation under a unified, elegant, and fluent API. Every hot path — parsing, RTTI marshalling, path-based editing, and schema validation — has been profiled and optimized against public, reproducible benchmarks, delivering native speeds for intensive web applications, APIs, and microservices.
 
 ### 🚀 Key Features
 
@@ -39,7 +38,6 @@
 | Environment / IDE | Platform / Compiler | Draft 7 Validator | Custom Middlewares |
 | :--- | :--- | :---: | :---: |
 | **Delphi XE or superior** | VCL, FMX, Console (Win/Linux/macOS/iOS/Android) | ✅ Yes | ✅ Yes |
-| **Lazarus / FreePascal** | LCL, Console (Cross-platform) | ✅ Yes | ✅ Yes |
 
 ### 📊 Performance & Benchmarks
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -2,10 +2,9 @@
   <img src="assets/logo.png" alt="JsonFlow Logo" width="380"/>
 </p>
 
-# JsonFlow — Serialização de JSON de alta performance, manipulação dinâmica e validação de Schema Draft-7 para Delphi/Lazarus
+# JsonFlow — Serialização de JSON de alta performance, manipulação dinâmica e validação de Schema Draft-7 para Delphi
 
 [![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20ou%20superior-blue.svg)]()
-[![Lazarus Compatible](https://img.shields.io/badge/Lazarus-Compatível-orange.svg)]()
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Security%20policy-success)](https://www.pubpascal.dev/packages/jsonflow)
 
@@ -17,7 +16,7 @@
 
 ---
 
-**JsonFlow** é um framework moderno, de alta performance e rico em recursos para manipulação, serialização e validação de JSON Schema Draft 7 em Delphi e Lazarus. Ele fornece um toolkit robusto e corporativo que integra perfeitamente serialização ultra-rápida de objetos, escrita e leitura dinâmica in-place e validação estruturada. Todos os hot paths — parse, marshalling RTTI, edição por path e validação de schema — foram auditados e otimizados contra benchmarks públicos e reproduzíveis, entregando velocidade nativa para servidores, microsserviços e APIs construídas em Object Pascal.
+**JsonFlow** é um framework moderno, de alta performance e rico em recursos para manipulação, serialização e validação de JSON Schema Draft 7 em Delphi. Ele fornece um toolkit robusto e corporativo que integra perfeitamente serialização ultra-rápida de objetos, escrita e leitura dinâmica in-place e validação estruturada. Todos os hot paths — parse, marshalling RTTI, edição por path e validação de schema — foram auditados e otimizados contra benchmarks públicos e reproduzíveis, entregando velocidade nativa para servidores, microsserviços e APIs construídas em Object Pascal.
 
 ### 🚀 Recursos Principais
 
@@ -35,7 +34,6 @@
 | Ambiente / IDE | Plataforma / Compilador | Validador Draft 7 | Middlewares Customizados |
 | :--- | :--- | :---: | :---: |
 | **Delphi XE ou superior** | VCL, FMX, Console (Win/Linux/macOS/iOS/Android) | ✅ Sim | ✅ Sim |
-| **Lazarus / FreePascal** | LCL, Console (Multiplataforma) | ✅ Sim | ✅ Sim |
 
 ### 📊 Performance & Benchmarks
 

--- a/Source/Core/JsonFlow.Builders.pas
+++ b/Source/Core/JsonFlow.Builders.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Core/JsonFlow.Types.pas
+++ b/Source/Core/JsonFlow.Types.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Core/JsonFlow.Utils.pas
+++ b/Source/Core/JsonFlow.Utils.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Composition/JsonFlow.Arrays.pas
+++ b/Source/JSON/Composition/JsonFlow.Arrays.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Composition/JsonFlow.Composer.pas
+++ b/Source/JSON/Composition/JsonFlow.Composer.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Composition/JsonFlow.Objects.pas
+++ b/Source/JSON/Composition/JsonFlow.Objects.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Composition/JsonFlow.Pair.pas
+++ b/Source/JSON/Composition/JsonFlow.Pair.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Core/JsonFlow.Converters.pas
+++ b/Source/JSON/Core/JsonFlow.Converters.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Core/JsonFlow.Interfaces.pas
+++ b/Source/JSON/Core/JsonFlow.Interfaces.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Core/JsonFlow.Value.pas
+++ b/Source/JSON/Core/JsonFlow.Value.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Converter.Dataset.pas
+++ b/Source/JSON/IO/JsonFlow.Converter.Dataset.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Navigator.pas
+++ b/Source/JSON/IO/JsonFlow.Navigator.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Reader.pas
+++ b/Source/JSON/IO/JsonFlow.Reader.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Serializer.Attributes.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.Attributes.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Serializer.CircularRef.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.CircularRef.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Serializer.Pool.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.Pool.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Serializer.pas
+++ b/Source/JSON/IO/JsonFlow.Serializer.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/IO/JsonFlow.Writer.pas
+++ b/Source/JSON/IO/JsonFlow.Writer.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JSON/Middleware/JsonFlow.MiddlewareDatatime.pas
+++ b/Source/JSON/Middleware/JsonFlow.MiddlewareDatatime.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/JsonFlow.pas
+++ b/Source/JsonFlow.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Middleware-Horse/Horse.JsonFlow.pas
+++ b/Source/Middleware-Horse/Horse.JsonFlow.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Composition/JsonFlow.SchemaComposer.pas
+++ b/Source/Schema/Composition/JsonFlow.SchemaComposer.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Composition/JsonFlow.SchemaNavigator.pas
+++ b/Source/Schema/Composition/JsonFlow.SchemaNavigator.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Core/JsonFlow.Schema.pas
+++ b/Source/Schema/Core/JsonFlow.Schema.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Core/JsonFlow.ValidationEngine.pas
+++ b/Source/Schema/Core/JsonFlow.ValidationEngine.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Core/JsonFlow.ValidationRules.pas
+++ b/Source/Schema/Core/JsonFlow.ValidationRules.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/IO/JsonFlow.SchemaReader.pas
+++ b/Source/Schema/IO/JsonFlow.SchemaReader.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/IO/JsonFlow.SchemaRefIndy.pas
+++ b/Source/Schema/IO/JsonFlow.SchemaRefIndy.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/IO/JsonFlow.SchemaRefSynapse.pas
+++ b/Source/Schema/IO/JsonFlow.SchemaRefSynapse.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.Brazil.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.Brazil.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianLicensePlate.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianLicensePlate.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianPhone.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.BrazilianPhone.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CEP.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CEP.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CNPJ.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CNPJ.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CPF.pas
+++ b/Source/Schema/Validators/Format/Brazil/JsonFlow.FormatValidators.CPF.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Base.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Base.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Date.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Date.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.DateTime.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.DateTime.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Email.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Email.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Ipv4.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Ipv4.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Ipv6.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Ipv6.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Time.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Time.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uri.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uri.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uuid.pas
+++ b/Source/Schema/Validators/Format/JsonFlow.FormatValidators.Uuid.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.FormatRegistry.pas
+++ b/Source/Schema/Validators/JsonFlow.FormatRegistry.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.FormatValidators.pas
+++ b/Source/Schema/Validators/JsonFlow.FormatValidators.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
+++ b/Source/Schema/Validators/JsonFlow.SchemaValidator.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.AdditionalProperties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.AdditionalProperties.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.AllOf.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.AllOf.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.AnyOf.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.AnyOf.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Base.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Base.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Conditional.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Conditional.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Consts.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Consts.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Contains.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Contains.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Content.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Content.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Dependencies.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Dependencies.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Enum.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Enum.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.ExclusiveMaximum.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.ExclusiveMaximum.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.ExclusiveMinimum.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.ExclusiveMinimum.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Format.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Format.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Items.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Items.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MaxItems.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MaxItems.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MaxLength.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MaxLength.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MaxProperties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MaxProperties.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Maximum.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Maximum.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MinItems.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MinItems.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MinLength.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MinLength.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MinProperties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MinProperties.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Minimum.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Minimum.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.MultipleOf.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.MultipleOf.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.NotRule.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.NotRule.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.OneOf.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.OneOf.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Pattern.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Pattern.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.PatternProperties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.PatternProperties.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Properties.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Properties.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.PropertyNames.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.PropertyNames.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Ref.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Ref.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Required.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Required.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.Types.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.Types.pas
@@ -1,7 +1,7 @@
 ﻿{
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Source/Schema/Validators/JsonFlow.ValidationRules.UniqueItems.pas
+++ b/Source/Schema/Validators/JsonFlow.ValidationRules.UniqueItems.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/Tests/Schema/Validators/JsonFlow.TestsSchemaSuiteHelper.pas
+++ b/Tests/Schema/Validators/JsonFlow.TestsSchemaSuiteHelper.pas
@@ -1,7 +1,7 @@
 {
   ------------------------------------------------------------------------------
   JsonFlow
-  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+  High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
   SPDX-License-Identifier: MIT
   Copyright (c) 2025-2026 Isaque Pinheiro

--- a/docs-src/docs/intro.md
+++ b/docs-src/docs/intro.md
@@ -16,7 +16,7 @@ Welcome to the **JsonFlow** technical documentation portal. Content is derived f
         <h3>JsonFlow</h3>
       </div>
       <div className="card__body">
-        <p>High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus. Provides object↔JSON mapping via RTTI, a fluent composer for in-place editing, and a full Draft 7 validator with detailed error paths. Performance add-ons: navigation cache (2.5×), batch mode (3.4×), and thread-safe object pooling (3×).</p>
+        <p>High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi. Provides object↔JSON mapping via RTTI, a fluent composer for in-place editing, and a full Draft 7 validator with detailed error paths. Performance add-ons: navigation cache (2.5×), batch mode (3.4×), and thread-safe object pooling (3×).</p>
       </div>
       <div className="card__footer">
         <a className="button button--primary" href="./jsonflow/">Open documentation →</a>
@@ -30,5 +30,4 @@ Welcome to the **JsonFlow** technical documentation portal. Content is derived f
 This portal matches the published source as of **2026-06-20**.
 
 - Win32/Win64: verified in production.
-- Lazarus/FreePascal: compatible (all platforms).
 - Draft 7 JSON Schema validation: full keyword coverage.

--- a/docs-src/docs/jsonflow/getting-started/installation.md
+++ b/docs-src/docs/jsonflow/getting-started/installation.md
@@ -63,6 +63,6 @@ Source\Addons\Validation\
 
 ## Requirements
 
-- Delphi XE or later **or** Lazarus / FreePascal (compatible)
+- Delphi XE or later
 - No external runtime dependencies for core functionality
 - `Horse` required only for `Horse.JsonFlow` middleware

--- a/docs-src/docs/jsonflow/index.md
+++ b/docs-src/docs/jsonflow/index.md
@@ -6,10 +6,9 @@ displayed_sidebar: jsonflowSidebar
 
 # JsonFlow
 
-**JsonFlow** is a high-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi and Lazarus.
+**JsonFlow** is a high-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation framework for Delphi.
 
 [![Delphi XE+](https://img.shields.io/badge/Delphi-XE%20or%20superior-blue.svg)]()
-[![Lazarus Compatible](https://img.shields.io/badge/Lazarus-Compatible-orange.svg)]()
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/ModernDelphiWorks/JsonFlow/blob/main/LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Security%20policy-success)](https://www.pubpascal.dev/packages/jsonflow)
 

--- a/docs-src/docs/jsonflow/introduction.md
+++ b/docs-src/docs/jsonflow/introduction.md
@@ -49,7 +49,6 @@ Both serialization (read/write) and schema validation support a middleware pipel
 | Environment | Platform | Draft 7 | Pooling |
 |---|---|:---:|:---:|
 | Delphi XE or later | VCL, FMX, Console (Win/Linux/macOS/iOS/Android) | Yes | Yes |
-| Lazarus / FreePascal | LCL, Console (cross-platform) | Yes | Yes |
 
 :::note Linux64 status
 Win32/Win64 is verified in production (2026-06-20). Linux64 consumer apps compile and run. A standalone full-framework Linux build has one tracked follow-up: `IEventMiddleware` is declared in both `JsonFlow.Types` and `JsonFlow.Interfaces` — choosing the canonical declaration resolves the ambiguity (this is not a platform issue).

--- a/docs-src/docusaurus.config.ts
+++ b/docs-src/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'JsonFlow',
-  tagline: 'High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation for Delphi and Lazarus',
+  tagline: 'High-performance JSON serialization, dynamic manipulation, and Draft 7 Schema validation for Delphi',
   favicon: 'img/favicon.svg',
 
   // Build output directory is set via CLI (`npm run build` → `docusaurus build --out-dir ../docs`)


### PR DESCRIPTION
## O que muda

Remove **toda** menção a Lazarus/FreePascal do projeto: cabeçalho das 81 units (`.pas`), títulos/badges/matriz de compatibilidade dos READMEs (EN e PT-BR), páginas do Docusaurus (`docs-src/docs`) e tagline do site (`docusaurus.config.ts`).

## Por quê

Verificação empírica em 2026-07-07 (Lazarus 2.2.6 + FPC 3.2.2, o estável mais atual): **o JsonFlow não compila em FPC** e não existe um único `{$IFDEF FPC}` no fonte — a alegação era aspiracional. Bloqueadores encontrados:

- `System.Rtti` (Interfaces/Serializer) — no FPC a unit é `Rtti`, parcial; o serializer inteiro depende dela (**o maior**)
- `reference to procedure` em `JsonFlow.Interfaces.pas:276-277` — FPC estável não tem métodos anônimos
- inline `var`/`for var` (Delphi 10.3+) em 11 units — nenhum FPC suporta
- `TRegEx`/`System.RegularExpressions` em 17 units — FPC só tem `RegExpr` (API diferente)
- `TFormatSettings.Create('en_US')` (`JsonFlow.Utils.pas:132`), `TNetEncoding`

## O que continua valendo

Compilação **verificada em 8/8 alvos Delphi 37.0** via unit agregadora (79 units core, zero erros): Win32, Win64, Win64x/ARM64EC, Linux64, macOS x64/ARM64, iOS device/simulator.

## Validação

- dcc32 recompilado após as edições: OK (mudanças em código são só na linha de comentário do cabeçalho)
- `git grep -il lazarus` (fora `temp_*`): 0 arquivos

🤖 Generated with [Claude Code](https://claude.com/claude-code)